### PR TITLE
Support writing fmp4 for Media Source Extensions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,13 +11,20 @@ repository = "https://github.com/alfg/mp4-rust"
 keywords = ["mp4", "iso-mp4", "isobmff", "video", "multimedia"]
 license = "MIT"
 
+[features]
+default = ["use_serde"]
+use_serde = ["serde", "serde_json"]
+
 [dependencies]
 thiserror = "^1.0"
 byteorder = "1"
 bytes = "0.5"
-num-rational = { version = "0.3", features = ["serde"] }
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
+serde = { version = "1.0", features = ["derive"], optional = true }
+serde_json = { version = "1.0", optional = true }
+
+num-traits = "0.2"
+
+log = "0.4"
 
 [dev-dependencies]
 criterion = "0.3"

--- a/benches/bench_main.rs
+++ b/benches/bench_main.rs
@@ -13,9 +13,13 @@ fn read_mp4(filename: &str) -> u64 {
 fn criterion_benchmark(c: &mut Criterion) {
     let filename = "tests/samples/minimal.mp4";
 
-    c.bench_with_input(BenchmarkId::new("input_example", filename), &filename, |b, &s| {
-        b.iter(|| read_mp4(s));
-    });
+    c.bench_with_input(
+        BenchmarkId::new("input_example", filename),
+        &filename,
+        |b, &s| {
+            b.iter(|| read_mp4(s));
+        },
+    );
 }
 
 criterion_group!(benches, criterion_benchmark);

--- a/examples/mp4copy.rs
+++ b/examples/mp4copy.rs
@@ -5,15 +5,9 @@ use std::io::{self, BufReader, BufWriter};
 use std::path::Path;
 
 use mp4::{
-    AacConfig,
-    AvcConfig,
-    HevcConfig,
+    AacConfig, AvcConfig, HevcConfig, MediaConfig, MediaType, Mp4Config, Result, TrackConfig,
     TtxtConfig,
-    MediaConfig,
-    MediaType,
-    Mp4Config,
-    Result,
-    TrackConfig};
+};
 
 fn main() {
     let args: Vec<String> = env::args().collect();

--- a/examples/mp4dump.rs
+++ b/examples/mp4dump.rs
@@ -4,7 +4,7 @@ use std::io::prelude::*;
 use std::io::{self, BufReader};
 use std::path::Path;
 
-use mp4::{Result, Mp4Box};
+use mp4::{Mp4Box, Result};
 
 fn main() {
     let args: Vec<String> = env::args().collect();
@@ -25,7 +25,10 @@ fn dump<P: AsRef<Path>>(filename: &P) -> Result<()> {
 
     // print out boxes
     for b in boxes.iter() {
-       println!("[{}] size={} {}", b.name, b.size, b.summary); 
+        for _ in 0..b.indent {
+            print!("  ");
+        }
+        println!("[{}] size={} {}", b.name, b.size, b.summary);
     }
 
     Ok(())
@@ -48,82 +51,83 @@ fn get_boxes(file: File) -> Result<Vec<Box>> {
     let mut boxes = Vec::new();
 
     // ftyp, moov, mvhd
-    boxes.push(build_box(&mp4.ftyp));
-    boxes.push(build_box(&mp4.moov));
-    boxes.push(build_box(&mp4.moov.mvhd));
+    boxes.push(build_box(&mp4.ftyp, 0));
+    boxes.push(build_box(&mp4.moov, 0));
+    boxes.push(build_box(&mp4.moov.mvhd, 1));
 
     if let Some(ref mvex) = &mp4.moov.mvex {
-        boxes.push(build_box(mvex));
-        boxes.push(build_box(&mvex.mehd));
-        boxes.push(build_box(&mvex.trex));
+        boxes.push(build_box(mvex, 1));
+        boxes.push(build_box(&mvex.mehd, 2));
+        boxes.push(build_box(&mvex.trex, 2));
     }
 
     // trak.
     for track in mp4.tracks().iter() {
-        boxes.push(build_box(&track.trak));
-        boxes.push(build_box(&track.trak.tkhd));
+        boxes.push(build_box(&track.trak, 1));
+        boxes.push(build_box(&track.trak.tkhd, 2));
         if let Some(ref edts) = track.trak.edts {
-            boxes.push(build_box(edts));
+            boxes.push(build_box(edts, 2));
             if let Some(ref elst) = edts.elst {
-                boxes.push(build_box(elst));
+                boxes.push(build_box(elst, 3));
             }
         }
 
         // trak.mdia
         let mdia = &track.trak.mdia;
-        boxes.push(build_box(mdia));
-        boxes.push(build_box(&mdia.mdhd));
-        boxes.push(build_box(&mdia.hdlr));
-        boxes.push(build_box(&track.trak.mdia.minf));
+        boxes.push(build_box(mdia, 2));
+        boxes.push(build_box(&mdia.mdhd, 3));
+        boxes.push(build_box(&mdia.hdlr, 3));
+        boxes.push(build_box(&mdia.minf, 3));
 
         // trak.mdia.minf
         let minf = &track.trak.mdia.minf;
+        boxes.push(descr_box("minf", 3));
         if let Some(ref vmhd) = &minf.vmhd {
-            boxes.push(build_box(vmhd));
+            boxes.push(build_box(vmhd, 4));
         }
         if let Some(ref smhd) = &minf.smhd {
-            boxes.push(build_box(smhd));
+            boxes.push(build_box(smhd, 4));
         }
 
         // trak.mdia.minf.stbl
         let stbl = &track.trak.mdia.minf.stbl;
-        boxes.push(build_box(stbl));
-        boxes.push(build_box(&stbl.stsd));
+        boxes.push(build_box(stbl, 4));
+        boxes.push(build_box(&stbl.stsd, 5));
         if let Some(ref avc1) = &stbl.stsd.avc1 {
-            boxes.push(build_box(avc1));
+            boxes.push(build_box(avc1, 6));
         }
         if let Some(ref hev1) = &stbl.stsd.hev1 {
-            boxes.push(build_box(hev1));
+            boxes.push(build_box(hev1, 6));
         }
         if let Some(ref mp4a) = &stbl.stsd.mp4a {
-            boxes.push(build_box(mp4a));
+            boxes.push(build_box(mp4a, 6));
         }
-        boxes.push(build_box(&stbl.stts));
+        boxes.push(build_box(&stbl.stts, 5));
         if let Some(ref ctts) = &stbl.ctts {
-            boxes.push(build_box(ctts));
+            boxes.push(build_box(ctts, 5));
         }
         if let Some(ref stss) = &stbl.stss {
-            boxes.push(build_box(stss));
+            boxes.push(build_box(stss, 5));
         }
-        boxes.push(build_box(&stbl.stsc));
-        boxes.push(build_box(&stbl.stsz));
+        boxes.push(build_box(&stbl.stsc, 5));
+        boxes.push(build_box(&stbl.stsz, 5));
         if let Some(ref stco) = &stbl.stco {
-            boxes.push(build_box(stco));
+            boxes.push(build_box(stco, 5));
         }
         if let Some(ref co64) = &stbl.co64 {
-            boxes.push(build_box(co64));
+            boxes.push(build_box(co64, 5));
         }
     }
 
     // If fragmented, add moof boxes.
     for moof in mp4.moofs.iter() {
-        boxes.push(build_box(moof));
-        boxes.push(build_box(&moof.mfhd));
+        boxes.push(build_box(moof, 0));
+        boxes.push(build_box(&moof.mfhd, 1));
         for traf in moof.trafs.iter() {
-            boxes.push(build_box(traf));
-            boxes.push(build_box(&traf.tfhd));
+            boxes.push(build_box(traf, 2));
+            boxes.push(build_box(&traf.tfhd, 3));
             if let Some(ref trun) = &traf.trun {
-                boxes.push(build_box(trun));
+                boxes.push(build_box(trun, 3));
             }
         }
     }
@@ -131,11 +135,20 @@ fn get_boxes(file: File) -> Result<Vec<Box>> {
     Ok(boxes)
 }
 
-fn build_box<M: Mp4Box + std::fmt::Debug>(ref m: &M) -> Box {
-    return Box{
+fn descr_box(name: &str, indent: u32) -> Box {
+    return Box {
+        name: name.to_string(),
+        size: 0,
+        summary: "".to_string(),
+        indent,
+    };
+}
+
+fn build_box<M: Mp4Box + std::fmt::Debug>(ref m: &M, indent: u32) -> Box {
+    return Box {
         name: m.box_type().to_string(),
         size: m.box_size(),
         summary: m.summary().unwrap(),
-        indent: 0,
+        indent: indent,
     };
 }

--- a/examples/mp4info.rs
+++ b/examples/mp4info.rs
@@ -4,7 +4,7 @@ use std::io::prelude::*;
 use std::io::{self, BufReader};
 use std::path::Path;
 
-use mp4::{Mp4Track, Result, TrackType, Error};
+use mp4::{Error, Mp4Track, Result, TrackType};
 
 fn main() {
     let args: Vec<String> = env::args().collect();
@@ -38,7 +38,10 @@ fn info<P: AsRef<Path>>(filename: &P) -> Result<()> {
 
     println!("Movie:");
     println!("  version:        {}", mp4.moov.mvhd.version);
-    println!("  creation time:  {}", creation_time(mp4.moov.mvhd.creation_time));
+    println!(
+        "  creation time:  {}",
+        creation_time(mp4.moov.mvhd.creation_time)
+    );
     println!("  duration:       {:?}", mp4.duration());
     println!("  fragments:      {:?}", mp4.is_fragmented());
     println!("  timescale:      {:?}\n", mp4.timescale());
@@ -89,7 +92,6 @@ fn video_info(track: &Mp4Track) -> Result<String> {
 fn audio_info(track: &Mp4Track) -> Result<String> {
     if let Some(ref mp4a) = track.trak.mdia.minf.stbl.stsd.mp4a {
         if mp4a.esds.is_some() {
-
             let profile = match track.audio_profile() {
                 Ok(val) => val.to_string(),
                 _ => "-".to_string(),
@@ -124,11 +126,7 @@ fn audio_info(track: &Mp4Track) -> Result<String> {
 
 fn subtitle_info(track: &Mp4Track) -> Result<String> {
     if track.trak.mdia.minf.stbl.stsd.tx3g.is_some() {
-        Ok(format!(
-            "{} ({:?})",
-            track.media_type()?,
-            track.box_type()?,
-        ))
+        Ok(format!("{} ({:?})", track.media_type()?, track.box_type()?,))
     } else {
         Err(Error::InvalidData("tx3g box not found"))
     }

--- a/examples/mp4sample.rs
+++ b/examples/mp4sample.rs
@@ -4,7 +4,7 @@ use std::io::prelude::*;
 use std::io::{self, BufReader};
 use std::path::Path;
 
-use mp4::{Result};
+use mp4::Result;
 
 fn main() {
     let args: Vec<String> = env::args().collect();
@@ -35,13 +35,14 @@ fn samples<P: AsRef<Path>>(filename: &P) -> Result<()> {
             let sample = mp4.read_sample(track_id, sample_id);
 
             if let Some(ref samp) = sample.unwrap() {
-                println!("[{}] start_time={} duration={} rendering_offset={} size={} is_sync={}",
-                  sample_id,
-                  samp.start_time,
-                  samp.duration,
-                  samp.rendering_offset,
-                  samp.bytes.len(),
-                  samp.is_sync,
+                println!(
+                    "[{}] start_time={} duration={} rendering_offset={} size={} is_sync={}",
+                    sample_id,
+                    samp.start_time,
+                    samp.duration,
+                    samp.rendering_offset,
+                    samp.bytes.len(),
+                    samp.is_sync,
                 );
             }
         }

--- a/examples/mp4tree.rs
+++ b/examples/mp4tree.rs
@@ -1,0 +1,192 @@
+use std::env;
+use std::fs::File;
+use std::io::prelude::*;
+use std::io::{self, BufReader};
+use std::path::Path;
+
+use mp4::mp4box::RootBox;
+use mp4::{Mp4Box, Mp4BoxReader, Result};
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+
+    if args.len() < 2 {
+        println!("Usage: mp4fragdump <filename>");
+        std::process::exit(1);
+    }
+
+    if let Err(err) = dump(&args[1]) {
+        let _ = writeln!(io::stderr(), "{}", err);
+    }
+}
+
+fn dump<P: AsRef<Path>>(filename: &P) -> Result<()> {
+    let f = File::open(filename)?;
+    let boxes = get_boxes(f)?;
+
+    // print out boxes
+    for b in boxes.iter() {
+        for _ in 0..b.indent {
+            print!("  ");
+        }
+        println!("[{}] size={} {}", b.name, b.size, b.summary);
+    }
+
+    Ok(())
+}
+
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct Box {
+    name: String,
+    size: u64,
+    summary: String,
+    indent: u32,
+}
+
+fn get_boxes(file: File) -> Result<Vec<Box>> {
+    let size = file.metadata()?.len();
+    let reader = BufReader::new(file);
+    let mp4 = Mp4BoxReader::read(reader, size)?;
+
+    // collect known boxes
+    let mut boxes = Vec::new();
+
+    for root_box in mp4.root_boxes() {
+        match root_box {
+            RootBox::FtypBox(ftyp) => {
+                println!("{}", ftyp.to_json().unwrap());
+                boxes.push(build_box(ftyp, 0));
+            }
+            RootBox::FreeBox(size) => {
+                boxes.push(Box {
+                    name: "free".into(),
+                    size: *size as u64,
+                    summary: "".into(),
+                    indent: 0,
+                });
+            }
+            RootBox::MdatBox(data) => {
+                boxes.push(Box {
+                    name: "mdat".into(),
+                    size: 0,
+                    summary: format!("{}", data),
+                    indent: 0,
+                });
+            }
+            RootBox::MoovBox(moov) => {
+                println!("{}", moov.to_json().unwrap());
+                boxes.push(build_box(moov, 0));
+                boxes.push(build_box(&moov.mvhd, 1));
+
+                if let Some(ref mvex) = &moov.mvex {
+                    boxes.push(build_box(mvex, 1));
+                    if let Some(mehd) = &mvex.mehd {
+                        boxes.push(build_box(mehd, 2));
+                    }
+                    boxes.push(build_box(&mvex.trex, 2));
+                }
+
+                // trak.
+                for trak in moov.traks.iter() {
+                    boxes.push(build_box(trak, 1));
+                    boxes.push(build_box(&trak.tkhd, 2));
+                    if let Some(ref edts) = trak.edts {
+                        boxes.push(build_box(edts, 2));
+                        if let Some(ref elst) = edts.elst {
+                            boxes.push(build_box(elst, 3));
+                        }
+                    }
+
+                    // trak.mdia
+                    let mdia = &trak.mdia;
+                    boxes.push(build_box(mdia, 2));
+                    boxes.push(build_box(&mdia.mdhd, 3));
+                    boxes.push(build_box(&mdia.hdlr, 3));
+
+                    // trak.mdia.minf
+                    let minf = &trak.mdia.minf;
+                    boxes.push(build_box(minf, 3));
+                    if let Some(ref vmhd) = &minf.vmhd {
+                        boxes.push(build_box(vmhd, 4));
+                    }
+                    if let Some(ref smhd) = &minf.smhd {
+                        boxes.push(build_box(smhd, 4));
+                    }
+
+                    let dinf = &minf.dinf;
+                    boxes.push(build_box(dinf, 4));
+                    boxes.push(build_box(&dinf.dref, 5));
+                    for entry in dinf.dref.data_entries.iter() {
+                        boxes.push(build_box(entry, 6));
+                    }
+
+                    // trak.mdia.minf.stbl
+                    let stbl = &trak.mdia.minf.stbl;
+                    boxes.push(build_box(stbl, 4));
+                    boxes.push(build_box(&stbl.stsd, 5));
+                    if let Some(ref avc1) = &stbl.stsd.avc1 {
+                        boxes.push(build_box(avc1, 6));
+                        boxes.push(build_box(&avc1.avcc, 7));
+                    }
+                    if let Some(ref avc2) = &stbl.stsd.avc2 {
+                        boxes.push(build_box(avc2, 6));
+                        boxes.push(build_box(&avc2.avcc, 7));
+                    }
+                    if let Some(ref avc3) = &stbl.stsd.avc3 {
+                        boxes.push(build_box(avc3, 6));
+                        boxes.push(build_box(&avc3.avcc, 7));
+                    }
+                    if let Some(ref hev1) = &stbl.stsd.hev1 {
+                        boxes.push(build_box(hev1, 6));
+                    }
+                    if let Some(ref mp4a) = &stbl.stsd.mp4a {
+                        boxes.push(build_box(mp4a, 6));
+                    }
+                    boxes.push(build_box(&stbl.stts, 5));
+                    if let Some(ref ctts) = &stbl.ctts {
+                        boxes.push(build_box(ctts, 5));
+                    }
+                    if let Some(ref stss) = &stbl.stss {
+                        boxes.push(build_box(stss, 5));
+                    }
+                    boxes.push(build_box(&stbl.stsc, 5));
+                    boxes.push(build_box(&stbl.stsz, 5));
+                    if let Some(ref stco) = &stbl.stco {
+                        boxes.push(build_box(stco, 5));
+                    }
+                    if let Some(ref co64) = &stbl.co64 {
+                        boxes.push(build_box(co64, 5));
+                    }
+                }
+            }
+            RootBox::MoofBox(moof) => {
+                println!("{}", moof.to_json().unwrap());
+                boxes.push(build_box(moof, 0));
+                boxes.push(build_box(&moof.mfhd, 1));
+                for traf in moof.trafs.iter() {
+                    boxes.push(build_box(traf, 1));
+                    boxes.push(build_box(&traf.tfhd, 2));
+                    if let Some(ref tfdt) = &traf.tfdt {
+                        boxes.push(build_box(tfdt, 2));
+                    }
+                    if let Some(ref trun) = &traf.trun {
+                        println!("{:#?}", trun);
+                        boxes.push(build_box(trun, 2));
+                    }
+                }
+            }
+            RootBox::Unknown(typ, data) => panic!("unknown fragment!! {:?} ({})", typ, data),
+        }
+    }
+
+    Ok(boxes)
+}
+
+fn build_box<M: Mp4Box + std::fmt::Debug>(ref m: &M, indent: u32) -> Box {
+    return Box {
+        name: m.box_type().to_string(),
+        size: m.box_size(),
+        summary: m.summary().unwrap(),
+        indent,
+    };
+}

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -17,7 +17,8 @@ fn main() {
     println!("Major Brand: {}", mp4.major_brand());
 
     for track in mp4.tracks().iter() {
-        println!("Track: #{}({}) {} {}",
+        println!(
+            "Track: #{}({}) {} {}",
             track.track_id(),
             track.language(),
             track.track_type().unwrap(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,14 +1,14 @@
 //! `mp4` is a Rust library to read and write ISO-MP4 files.
-//! 
+//!
 //! This package contains MPEG-4 specifications defined in parts:
 //!    * ISO/IEC 14496-12 - ISO Base Media File Format (QuickTime, MPEG-4, etc)
 //!    * ISO/IEC 14496-14 - MP4 file format
 //!    * ISO/IEC 14496-17 - Streaming text format
-//! 
+//!
 //! See: [mp4box] for supported MP4 atoms.
-//! 
+//!
 //! ### Example
-//! 
+//!
 //! ```
 //! use std::fs::File;
 //! use std::io::{BufReader};
@@ -49,9 +49,9 @@
 //!    Ok(())
 //! }
 //! ```
-//! 
+//!
 //! See [examples] for more examples.
-//! 
+//!
 //! # Installation
 //!
 //! Add the following to your `Cargo.toml` file:
@@ -60,14 +60,13 @@
 //! [dependencies]
 //! mp4 = "0.7.0"
 //! ```
-//! 
+//!
 //! [mp4box]: https://github.com/alfg/mp4-rust/blob/master/src/mp4box/mod.rs
 //! [examples]: https://github.com/alfg/mp4-rust/blob/master/src/examples
 #![doc(html_root_url = "https://docs.rs/mp4/*")]
 
-
-use std::io::{BufReader};
 use std::fs::File;
+use std::io::BufReader;
 
 mod error;
 pub use error::Error;
@@ -77,17 +76,20 @@ pub type Result<T> = std::result::Result<T, Error>;
 mod types;
 pub use types::*;
 
-mod mp4box;
-pub use mp4box::{Mp4Box};
+pub mod mp4box;
+pub use mp4box::Mp4Box;
 
 mod track;
 pub use track::{Mp4Track, TrackConfig};
 
 mod reader;
-pub use reader::Mp4Reader;
+pub use reader::{Mp4BoxReader, Mp4Reader};
 
 mod writer;
 pub use writer::{Mp4Config, Mp4Writer};
+
+mod sample_flags;
+pub use sample_flags::*;
 
 pub fn read_mp4(f: File) -> Result<Mp4Reader<BufReader<File>>> {
     let size = f.metadata()?.len();

--- a/src/mp4box/co64.rs
+++ b/src/mp4box/co64.rs
@@ -1,15 +1,17 @@
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
+#[cfg(feature = "use_serde")]
+use serde::Serialize;
 use std::io::{Read, Seek, Write};
-use serde::{Serialize};
 
 use crate::mp4box::*;
 
-#[derive(Debug, Clone, PartialEq, Default, Serialize)]
+#[derive(Debug, Clone, PartialEq, Default)]
+#[cfg_attr(feature = "use_serde", derive(Serialize))]
 pub struct Co64Box {
     pub version: u8,
     pub flags: u32,
 
-    #[serde(skip_serializing)]
+    #[cfg_attr(feature = "use_serde", serde(skip_serializing))]
     pub entries: Vec<u64>,
 }
 
@@ -32,6 +34,7 @@ impl Mp4Box for Co64Box {
         return self.get_size();
     }
 
+    #[cfg(feature = "use_serde")]
     fn to_json(&self) -> Result<String> {
         Ok(serde_json::to_string(&self).unwrap())
     }

--- a/src/mp4box/ctts.rs
+++ b/src/mp4box/ctts.rs
@@ -1,15 +1,17 @@
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
+#[cfg(feature = "use_serde")]
+use serde::Serialize;
 use std::io::{Read, Seek, Write};
-use serde::{Serialize};
 
 use crate::mp4box::*;
 
-#[derive(Debug, Clone, PartialEq, Default, Serialize)]
+#[derive(Debug, Clone, PartialEq, Default)]
+#[cfg_attr(feature = "use_serde", derive(Serialize))]
 pub struct CttsBox {
     pub version: u8,
     pub flags: u32,
 
-    #[serde(skip_serializing)]
+    #[cfg_attr(feature = "use_serde", serde(skip_serializing))]
     pub entries: Vec<CttsEntry>,
 }
 
@@ -23,7 +25,8 @@ impl CttsBox {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Default, Serialize)]
+#[derive(Debug, Clone, PartialEq, Default)]
+#[cfg_attr(feature = "use_serde", derive(Serialize))]
 pub struct CttsEntry {
     pub sample_count: u32,
     pub sample_offset: i32,
@@ -38,6 +41,8 @@ impl Mp4Box for CttsBox {
         return self.get_size();
     }
 
+    #[cfg(feature = "use_serde")]
+    #[cfg(feature = "use_serde")]
     fn to_json(&self) -> Result<String> {
         Ok(serde_json::to_string(&self).unwrap())
     }

--- a/src/mp4box/edts.rs
+++ b/src/mp4box/edts.rs
@@ -1,10 +1,12 @@
+#[cfg(feature = "use_serde")]
+use serde::Serialize;
 use std::io::{Read, Seek, Write};
-use serde::{Serialize};
 
 use crate::mp4box::elst::ElstBox;
 use crate::mp4box::*;
 
-#[derive(Debug, Clone, PartialEq, Default, Serialize)]
+#[derive(Debug, Clone, PartialEq, Default)]
+#[cfg_attr(feature = "use_serde", derive(Serialize))]
 pub struct EdtsBox {
     pub elst: Option<ElstBox>,
 }
@@ -36,6 +38,8 @@ impl Mp4Box for EdtsBox {
         return self.get_size();
     }
 
+    #[cfg(feature = "use_serde")]
+    #[cfg(feature = "use_serde")]
     fn to_json(&self) -> Result<String> {
         Ok(serde_json::to_string(&self).unwrap())
     }

--- a/src/mp4box/elst.rs
+++ b/src/mp4box/elst.rs
@@ -1,19 +1,22 @@
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
+#[cfg(feature = "use_serde")]
+use serde::Serialize;
 use std::io::{Read, Seek, Write};
-use serde::{Serialize};
 
 use crate::mp4box::*;
 
-#[derive(Debug, Clone, PartialEq, Default, Serialize)]
+#[derive(Debug, Clone, PartialEq, Default)]
+#[cfg_attr(feature = "use_serde", derive(Serialize))]
 pub struct ElstBox {
     pub version: u8,
     pub flags: u32,
 
-    #[serde(skip_serializing)]
+    #[cfg_attr(feature = "use_serde", serde(skip_serializing))]
     pub entries: Vec<ElstEntry>,
 }
 
-#[derive(Debug, Clone, PartialEq, Default, Serialize)]
+#[derive(Debug, Clone, PartialEq, Default)]
+#[cfg_attr(feature = "use_serde", derive(Serialize))]
 pub struct ElstEntry {
     pub segment_duration: u64,
     pub media_time: u64,
@@ -47,6 +50,8 @@ impl Mp4Box for ElstBox {
         return self.get_size();
     }
 
+    #[cfg(feature = "use_serde")]
+    #[cfg(feature = "use_serde")]
     fn to_json(&self) -> Result<String> {
         Ok(serde_json::to_string(&self).unwrap())
     }

--- a/src/mp4box/ftyp.rs
+++ b/src/mp4box/ftyp.rs
@@ -1,10 +1,12 @@
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
+#[cfg(feature = "use_serde")]
+use serde::Serialize;
 use std::io::{Read, Seek, Write};
-use serde::{Serialize};
 
 use crate::mp4box::*;
 
-#[derive(Debug, Clone, PartialEq, Default, Serialize)]
+#[derive(Debug, Clone, PartialEq, Default)]
+#[cfg_attr(feature = "use_serde", derive(Serialize))]
 pub struct FtypBox {
     pub major_brand: FourCC,
     pub minor_version: u32,
@@ -30,6 +32,7 @@ impl Mp4Box for FtypBox {
         return self.get_size();
     }
 
+    #[cfg(feature = "use_serde")]
     fn to_json(&self) -> Result<String> {
         Ok(serde_json::to_string(&self).unwrap())
     }
@@ -39,8 +42,12 @@ impl Mp4Box for FtypBox {
         for brand in self.compatible_brands.iter() {
             compatible_brands.push(brand.to_string());
         }
-        let s = format!("major_brand={} minor_version={} compatible_brands={}",
-            self.major_brand, self.minor_version, compatible_brands.join("-"));
+        let s = format!(
+            "major_brand={} minor_version={} compatible_brands={}",
+            self.major_brand,
+            self.minor_version,
+            compatible_brands.join("-")
+        );
         Ok(s)
     }
 }

--- a/src/mp4box/hdlr.rs
+++ b/src/mp4box/hdlr.rs
@@ -1,10 +1,12 @@
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
+#[cfg(feature = "use_serde")]
+use serde::Serialize;
 use std::io::{Read, Seek, Write};
-use serde::{Serialize};
 
 use crate::mp4box::*;
 
-#[derive(Debug, Clone, PartialEq, Default, Serialize)]
+#[derive(Debug, Clone, PartialEq, Default)]
+#[cfg_attr(feature = "use_serde", derive(Serialize))]
 pub struct HdlrBox {
     pub version: u8,
     pub flags: u32,
@@ -31,12 +33,17 @@ impl Mp4Box for HdlrBox {
         return self.get_size();
     }
 
+    #[cfg(feature = "use_serde")]
     fn to_json(&self) -> Result<String> {
         Ok(serde_json::to_string(&self).unwrap())
     }
 
     fn summary(&self) -> Result<String> {
-        let s = format!("handler_type={} name={}", self.handler_type.to_string(), self.name);
+        let s = format!(
+            "handler_type={} name={}",
+            self.handler_type.to_string(),
+            self.name
+        );
         Ok(s)
     }
 }

--- a/src/mp4box/mdhd.rs
+++ b/src/mp4box/mdhd.rs
@@ -1,11 +1,13 @@
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
+#[cfg(feature = "use_serde")]
+use serde::Serialize;
 use std::char::{decode_utf16, REPLACEMENT_CHARACTER};
 use std::io::{Read, Seek, Write};
-use serde::{Serialize};
 
 use crate::mp4box::*;
 
-#[derive(Debug, Clone, PartialEq, Serialize)]
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "use_serde", derive(Serialize))]
 pub struct MdhdBox {
     pub version: u8,
     pub flags: u32,
@@ -58,13 +60,17 @@ impl Mp4Box for MdhdBox {
         return self.get_size();
     }
 
+    #[cfg(feature = "use_serde")]
+    #[cfg(feature = "use_serde")]
     fn to_json(&self) -> Result<String> {
         Ok(serde_json::to_string(&self).unwrap())
     }
 
     fn summary(&self) -> Result<String> {
-        let s = format!("creation_time={} timescale={} duration={} language={}",
-            self.creation_time, self.timescale, self.duration, self.language);
+        let s = format!(
+            "creation_time={} timescale={} duration={} language={}",
+            self.creation_time, self.timescale, self.duration, self.language
+        );
         Ok(s)
     }
 }

--- a/src/mp4box/mdia.rs
+++ b/src/mp4box/mdia.rs
@@ -1,10 +1,12 @@
+#[cfg(feature = "use_serde")]
+use serde::Serialize;
 use std::io::{Read, Seek, SeekFrom, Write};
-use serde::{Serialize};
 
 use crate::mp4box::*;
 use crate::mp4box::{hdlr::HdlrBox, mdhd::MdhdBox, minf::MinfBox};
 
-#[derive(Debug, Clone, PartialEq, Default, Serialize)]
+#[derive(Debug, Clone, PartialEq, Default)]
+#[cfg_attr(feature = "use_serde", derive(Serialize))]
 pub struct MdiaBox {
     pub mdhd: MdhdBox,
     pub hdlr: HdlrBox,
@@ -30,6 +32,8 @@ impl Mp4Box for MdiaBox {
         return self.get_size();
     }
 
+    #[cfg(feature = "use_serde")]
+    #[cfg(feature = "use_serde")]
     fn to_json(&self) -> Result<String> {
         Ok(serde_json::to_string(&self).unwrap())
     }

--- a/src/mp4box/mehd.rs
+++ b/src/mp4box/mehd.rs
@@ -1,10 +1,12 @@
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
+#[cfg(feature = "use_serde")]
+use serde::Serialize;
 use std::io::{Read, Seek, Write};
-use serde::{Serialize};
 
 use crate::mp4box::*;
 
-#[derive(Debug, Clone, PartialEq, Serialize)]
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "use_serde", derive(Serialize))]
 pub struct MehdBox {
     pub version: u8,
     pub flags: u32,
@@ -48,6 +50,8 @@ impl Mp4Box for MehdBox {
         return self.get_size();
     }
 
+    #[cfg(feature = "use_serde")]
+    #[cfg(feature = "use_serde")]
     fn to_json(&self) -> Result<String> {
         Ok(serde_json::to_string(&self).unwrap())
     }
@@ -103,7 +107,6 @@ mod tests {
     use super::*;
     use crate::mp4box::BoxHeader;
     use std::io::Cursor;
-
 
     #[test]
     fn test_mehd32() {

--- a/src/mp4box/mfhd.rs
+++ b/src/mp4box/mfhd.rs
@@ -1,10 +1,12 @@
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
+#[cfg(feature = "use_serde")]
+use serde::Serialize;
 use std::io::{Read, Seek, Write};
-use serde::{Serialize};
 
 use crate::mp4box::*;
 
-#[derive(Debug, Clone, PartialEq, Serialize)]
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "use_serde", derive(Serialize))]
 pub struct MfhdBox {
     pub version: u8,
     pub flags: u32,
@@ -27,7 +29,7 @@ impl MfhdBox {
     }
 
     pub fn get_size(&self) -> u64 {
-        HEADER_SIZE + HEADER_EXT_SIZE + 4 
+        HEADER_SIZE + HEADER_EXT_SIZE + 4
     }
 }
 
@@ -40,6 +42,7 @@ impl Mp4Box for MfhdBox {
         return self.get_size();
     }
 
+    #[cfg(feature = "use_serde")]
     fn to_json(&self) -> Result<String> {
         Ok(serde_json::to_string(&self).unwrap())
     }

--- a/src/mp4box/minf.rs
+++ b/src/mp4box/minf.rs
@@ -1,15 +1,17 @@
+#[cfg(feature = "use_serde")]
+use serde::Serialize;
 use std::io::{Read, Seek, SeekFrom, Write};
-use serde::{Serialize};
 
 use crate::mp4box::*;
 use crate::mp4box::{dinf::DinfBox, smhd::SmhdBox, stbl::StblBox, vmhd::VmhdBox};
 
-#[derive(Debug, Clone, PartialEq, Default, Serialize)]
+#[derive(Debug, Clone, PartialEq, Default)]
+#[cfg_attr(feature = "use_serde", derive(Serialize))]
 pub struct MinfBox {
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "use_serde", serde(skip_serializing_if = "Option::is_none"))]
     pub vmhd: Option<VmhdBox>,
 
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "use_serde", serde(skip_serializing_if = "Option::is_none"))]
     pub smhd: Option<SmhdBox>,
 
     pub dinf: DinfBox,
@@ -44,6 +46,7 @@ impl Mp4Box for MinfBox {
         return self.get_size();
     }
 
+    #[cfg(feature = "use_serde")]
     fn to_json(&self) -> Result<String> {
         Ok(serde_json::to_string(&self).unwrap())
     }

--- a/src/mp4box/stbl.rs
+++ b/src/mp4box/stbl.rs
@@ -1,35 +1,31 @@
+#[cfg(feature = "use_serde")]
+use serde::Serialize;
 use std::io::{Read, Seek, SeekFrom, Write};
-use serde::{Serialize};
 
 use crate::mp4box::*;
 use crate::mp4box::{
-    co64::Co64Box,
-    ctts::CttsBox,
-    stco::StcoBox,
-    stsc::StscBox,
-    stsd::StsdBox,
-    stss::StssBox,
-    stsz::StszBox,
-    stts::SttsBox,
+    co64::Co64Box, ctts::CttsBox, stco::StcoBox, stsc::StscBox, stsd::StsdBox, stss::StssBox,
+    stsz::StszBox, stts::SttsBox,
 };
 
-#[derive(Debug, Clone, PartialEq, Default, Serialize)]
+#[derive(Debug, Clone, PartialEq, Default)]
+#[cfg_attr(feature = "use_serde", derive(Serialize))]
 pub struct StblBox {
     pub stsd: StsdBox,
     pub stts: SttsBox,
 
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "use_serde", serde(skip_serializing_if = "Option::is_none"))]
     pub ctts: Option<CttsBox>,
 
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "use_serde", serde(skip_serializing_if = "Option::is_none"))]
     pub stss: Option<StssBox>,
     pub stsc: StscBox,
     pub stsz: StszBox,
 
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "use_serde", serde(skip_serializing_if = "Option::is_none"))]
     pub stco: Option<StcoBox>,
 
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "use_serde", serde(skip_serializing_if = "Option::is_none"))]
     pub co64: Option<Co64Box>,
 }
 
@@ -69,6 +65,7 @@ impl Mp4Box for StblBox {
         return self.get_size();
     }
 
+    #[cfg(feature = "use_serde")]
     fn to_json(&self) -> Result<String> {
         Ok(serde_json::to_string(&self).unwrap())
     }

--- a/src/mp4box/stco.rs
+++ b/src/mp4box/stco.rs
@@ -1,15 +1,17 @@
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
+#[cfg(feature = "use_serde")]
+use serde::Serialize;
 use std::io::{Read, Seek, Write};
-use serde::{Serialize};
 
 use crate::mp4box::*;
 
-#[derive(Debug, Clone, PartialEq, Default, Serialize)]
+#[derive(Debug, Clone, PartialEq, Default)]
+#[cfg_attr(feature = "use_serde", derive(Serialize))]
 pub struct StcoBox {
     pub version: u8,
     pub flags: u32,
 
-    #[serde(skip_serializing)]
+    #[cfg_attr(feature = "use_serde", serde(skip_serializing))]
     pub entries: Vec<u32>,
 }
 
@@ -32,6 +34,7 @@ impl Mp4Box for StcoBox {
         return self.get_size();
     }
 
+    #[cfg(feature = "use_serde")]
     fn to_json(&self) -> Result<String> {
         Ok(serde_json::to_string(&self).unwrap())
     }

--- a/src/mp4box/stsc.rs
+++ b/src/mp4box/stsc.rs
@@ -1,15 +1,17 @@
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
+#[cfg(feature = "use_serde")]
+use serde::Serialize;
 use std::io::{Read, Seek, Write};
-use serde::{Serialize};
 
 use crate::mp4box::*;
 
-#[derive(Debug, Clone, PartialEq, Default, Serialize)]
+#[derive(Debug, Clone, PartialEq, Default)]
+#[cfg_attr(feature = "use_serde", derive(Serialize))]
 pub struct StscBox {
     pub version: u8,
     pub flags: u32,
 
-    #[serde(skip_serializing)]
+    #[cfg_attr(feature = "use_serde", serde(skip_serializing))]
     pub entries: Vec<StscEntry>,
 }
 
@@ -23,7 +25,8 @@ impl StscBox {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Default, Serialize)]
+#[derive(Debug, Clone, PartialEq, Default)]
+#[cfg_attr(feature = "use_serde", derive(Serialize))]
 pub struct StscEntry {
     pub first_chunk: u32,
     pub samples_per_chunk: u32,
@@ -40,6 +43,7 @@ impl Mp4Box for StscBox {
         return self.get_size();
     }
 
+    #[cfg(feature = "use_serde")]
     fn to_json(&self) -> Result<String> {
         Ok(serde_json::to_string(&self).unwrap())
     }

--- a/src/mp4box/stss.rs
+++ b/src/mp4box/stss.rs
@@ -1,15 +1,17 @@
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
+#[cfg(feature = "use_serde")]
+use serde::Serialize;
 use std::io::{Read, Seek, Write};
-use serde::{Serialize};
 
 use crate::mp4box::*;
 
-#[derive(Debug, Clone, PartialEq, Default, Serialize)]
+#[derive(Debug, Clone, PartialEq, Default)]
+#[cfg_attr(feature = "use_serde", derive(Serialize))]
 pub struct StssBox {
     pub version: u8,
     pub flags: u32,
 
-    #[serde(skip_serializing)]
+    #[cfg_attr(feature = "use_serde", serde(skip_serializing))]
     pub entries: Vec<u32>,
 }
 
@@ -32,6 +34,7 @@ impl Mp4Box for StssBox {
         return self.get_size();
     }
 
+    #[cfg(feature = "use_serde")]
     fn to_json(&self) -> Result<String> {
         Ok(serde_json::to_string(&self).unwrap())
     }

--- a/src/mp4box/stsz.rs
+++ b/src/mp4box/stsz.rs
@@ -1,17 +1,19 @@
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
+#[cfg(feature = "use_serde")]
+use serde::Serialize;
 use std::io::{Read, Seek, Write};
-use serde::{Serialize};
 
 use crate::mp4box::*;
 
-#[derive(Debug, Clone, PartialEq, Default, Serialize)]
+#[derive(Debug, Clone, PartialEq, Default)]
+#[cfg_attr(feature = "use_serde", derive(Serialize))]
 pub struct StszBox {
     pub version: u8,
     pub flags: u32,
     pub sample_size: u32,
     pub sample_count: u32,
 
-    #[serde(skip_serializing)]
+    #[cfg_attr(feature = "use_serde", serde(skip_serializing))]
     pub sample_sizes: Vec<u32>,
 }
 
@@ -34,13 +36,18 @@ impl Mp4Box for StszBox {
         return self.get_size();
     }
 
+    #[cfg(feature = "use_serde")]
     fn to_json(&self) -> Result<String> {
         Ok(serde_json::to_string(&self).unwrap())
     }
 
     fn summary(&self) -> Result<String> {
-        let s = format!("sample_size={} sample_count={} sample_sizes={}",
-            self.sample_size, self.sample_count, self.sample_sizes.len());
+        let s = format!(
+            "sample_size={} sample_count={} sample_sizes={}",
+            self.sample_size,
+            self.sample_count,
+            self.sample_sizes.len()
+        );
         Ok(s)
     }
 }

--- a/src/mp4box/stts.rs
+++ b/src/mp4box/stts.rs
@@ -1,15 +1,17 @@
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
+#[cfg(feature = "use_serde")]
+use serde::Serialize;
 use std::io::{Read, Seek, Write};
-use serde::{Serialize};
 
 use crate::mp4box::*;
 
-#[derive(Debug, Clone, PartialEq, Default, Serialize)]
+#[derive(Debug, Clone, PartialEq, Default)]
+#[cfg_attr(feature = "use_serde", derive(Serialize))]
 pub struct SttsBox {
     pub version: u8,
     pub flags: u32,
 
-    #[serde(skip_serializing)]
+    #[cfg_attr(feature = "use_serde", serde(skip_serializing))]
     pub entries: Vec<SttsEntry>,
 }
 
@@ -23,7 +25,8 @@ impl SttsBox {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Default, Serialize)]
+#[derive(Debug, Clone, PartialEq, Default)]
+#[cfg_attr(feature = "use_serde", derive(Serialize))]
 pub struct SttsEntry {
     pub sample_count: u32,
     pub sample_delta: u32,
@@ -38,6 +41,7 @@ impl Mp4Box for SttsBox {
         return self.get_size();
     }
 
+    #[cfg(feature = "use_serde")]
     fn to_json(&self) -> Result<String> {
         Ok(serde_json::to_string(&self).unwrap())
     }

--- a/src/mp4box/tfdt.rs
+++ b/src/mp4box/tfdt.rs
@@ -1,0 +1,96 @@
+use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
+#[cfg(feature = "use_serde")]
+use serde::Serialize;
+use std::convert::TryInto;
+use std::io::{Read, Seek, Write};
+
+use crate::mp4box::*;
+
+// Track Fragment Decode Time box
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "use_serde", derive(Serialize))]
+pub struct TfdtBox {
+    pub version: u8,
+
+    pub base_media_decode_time: u64,
+}
+
+impl Default for TfdtBox {
+    fn default() -> Self {
+        Self {
+            version: 0,
+            base_media_decode_time: 0,
+        }
+    }
+}
+
+impl TfdtBox {
+    pub fn get_type(&self) -> BoxType {
+        BoxType::TfdtBox
+    }
+
+    pub fn get_size(&self) -> u64 {
+        let mut size = HEADER_SIZE + HEADER_EXT_SIZE;
+        match self.version {
+            0 => size += 4,
+            1 => size += 8,
+            _ => panic!(),
+        }
+        size
+    }
+}
+
+impl Mp4Box for TfdtBox {
+    fn box_type(&self) -> BoxType {
+        self.get_type()
+    }
+
+    fn box_size(&self) -> u64 {
+        self.get_size()
+    }
+
+    #[cfg(feature = "use_serde")]
+    fn to_json(&self) -> Result<String> {
+        Ok(serde_json::to_string(&self).unwrap())
+    }
+
+    fn summary(&self) -> Result<String> {
+        let s = format!("decode_time={}", self.base_media_decode_time);
+        Ok(s)
+    }
+}
+
+impl<R: Read + Seek> ReadBox<&mut R> for TfdtBox {
+    fn read_box(reader: &mut R, size: u64) -> Result<Self> {
+        let _start = box_start(reader)?;
+        let (version, _flags) = read_box_header_ext(reader)?;
+
+        let base_media_decode_time = match version {
+            0 => reader.read_u32::<BigEndian>()? as u64,
+            1 => reader.read_u64::<BigEndian>()?,
+            _ => panic!(),
+        };
+
+        Ok(TfdtBox {
+            version,
+            base_media_decode_time,
+        })
+    }
+}
+
+impl<W: Write> WriteBox<&mut W> for TfdtBox {
+    fn write_box(&self, writer: &mut W) -> Result<u64> {
+        let size = self.box_size();
+        BoxHeader::new(self.box_type(), size).write(writer)?;
+
+        write_box_header_ext(writer, self.version, 0)?;
+
+        match self.version {
+            0 => writer.write_u32::<BigEndian>(self.base_media_decode_time.try_into().unwrap())?,
+            1 => writer.write_u64::<BigEndian>(self.base_media_decode_time)?,
+            _ => panic!(),
+        }
+
+        Ok(size)
+    }
+}

--- a/src/mp4box/tfhd.rs
+++ b/src/mp4box/tfhd.rs
@@ -1,24 +1,43 @@
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
+#[cfg(feature = "use_serde")]
+use serde::Serialize;
 use std::io::{Read, Seek, Write};
-use serde::{Serialize};
 
 use crate::mp4box::*;
 
-#[derive(Debug, Clone, PartialEq, Serialize)]
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "use_serde", derive(Serialize))]
 pub struct TfhdBox {
     pub version: u8,
-    pub flags: u32,
     pub track_id: u32,
-    pub base_data_offset: u64,
+
+    #[cfg_attr(feature = "use_serde", serde(skip_serializing_if = "Option::is_none"))]
+    pub base_data_offset: Option<u64>,
+    #[cfg_attr(feature = "use_serde", serde(skip_serializing_if = "Option::is_none"))]
+    pub sample_description_index: Option<u32>,
+    #[cfg_attr(feature = "use_serde", serde(skip_serializing_if = "Option::is_none"))]
+    pub default_sample_duration: Option<u32>,
+    #[cfg_attr(feature = "use_serde", serde(skip_serializing_if = "Option::is_none"))]
+    pub default_sample_size: Option<u32>,
+    #[cfg_attr(feature = "use_serde", serde(skip_serializing_if = "Option::is_none"))]
+    pub default_sample_flags: Option<u32>,
+
+    pub duration_is_empty: bool,
+    pub default_base_is_moof: bool,
 }
 
 impl Default for TfhdBox {
     fn default() -> Self {
         TfhdBox {
             version: 0,
-            flags: 0,
             track_id: 0,
-            base_data_offset: 0,
+            base_data_offset: Some(0),
+            sample_description_index: None,
+            default_sample_duration: None,
+            default_sample_size: None,
+            default_sample_flags: None,
+            duration_is_empty: false,
+            default_base_is_moof: false,
         }
     }
 }
@@ -29,7 +48,24 @@ impl TfhdBox {
     }
 
     pub fn get_size(&self) -> u64 {
-        HEADER_SIZE + HEADER_EXT_SIZE + 4 + 8
+        let mut size = HEADER_SIZE + HEADER_EXT_SIZE;
+        size += 4;
+        if self.base_data_offset.is_some() {
+            size += 8;
+        }
+        if self.sample_description_index.is_some() {
+            size += 4;
+        }
+        if self.default_sample_duration.is_some() {
+            size += 4;
+        }
+        if self.default_sample_size.is_some() {
+            size += 4;
+        }
+        if self.default_sample_flags.is_some() {
+            size += 4;
+        }
+        size
     }
 }
 
@@ -42,6 +78,7 @@ impl Mp4Box for TfhdBox {
         return self.get_size();
     }
 
+    #[cfg(feature = "use_serde")]
     fn to_json(&self) -> Result<String> {
         Ok(serde_json::to_string(&self).unwrap())
     }
@@ -57,16 +94,57 @@ impl<R: Read + Seek> ReadBox<&mut R> for TfhdBox {
         let start = box_start(reader)?;
 
         let (version, flags) = read_box_header_ext(reader)?;
+
+        let base_data_offset_present = (flags & 0x000001) != 0;
+        let sample_description_index_present = (flags & 0x000002) != 0;
+        let default_sample_duration_present = (flags & 0x000008) != 0;
+        let default_sample_size_present = (flags & 0x000010) != 0;
+        let default_sample_flags_present = (flags & 0x000020) != 0;
+        let duration_is_empty = (flags & 0x010000) != 0;
+        let default_base_is_moof = (flags & 0x020000) != 0;
+
         let track_id = reader.read_u32::<BigEndian>()?;
-        let base_data_offset = reader.read_u64::<BigEndian>()?;
+
+        let base_data_offset = if base_data_offset_present {
+            Some(reader.read_u64::<BigEndian>()?)
+        } else {
+            None
+        };
+        let sample_description_index = if sample_description_index_present {
+            Some(reader.read_u32::<BigEndian>()?)
+        } else {
+            None
+        };
+        let default_sample_duration = if default_sample_duration_present {
+            Some(reader.read_u32::<BigEndian>()?)
+        } else {
+            None
+        };
+        let default_sample_size = if default_sample_size_present {
+            Some(reader.read_u32::<BigEndian>()?)
+        } else {
+            None
+        };
+        let default_sample_flags = if default_sample_flags_present {
+            Some(reader.read_u32::<BigEndian>()?)
+        } else {
+            None
+        };
 
         skip_bytes_to(reader, start + size)?;
 
         Ok(TfhdBox {
             version,
-            flags,
             track_id,
+
             base_data_offset,
+            sample_description_index,
+            default_sample_duration,
+            default_sample_size,
+            default_sample_flags,
+
+            duration_is_empty,
+            default_base_is_moof,
         })
     }
 }
@@ -76,9 +154,48 @@ impl<W: Write> WriteBox<&mut W> for TfhdBox {
         let size = self.box_size();
         BoxHeader::new(self.box_type(), size).write(writer)?;
 
-        write_box_header_ext(writer, self.version, self.flags)?;
+        let mut flags = 0;
+        if self.base_data_offset.is_some() {
+            flags |= 0x000001;
+        }
+        if self.sample_description_index.is_some() {
+            flags |= 0x000002;
+        }
+        if self.default_sample_duration.is_some() {
+            flags |= 0x000008;
+        }
+        if self.default_sample_size.is_some() {
+            flags |= 0x000010;
+        }
+        if self.default_sample_flags.is_some() {
+            flags |= 0x000020;
+        }
+        if self.duration_is_empty {
+            flags |= 0x010000;
+        }
+        if self.default_base_is_moof {
+            flags |= 0x020000;
+        }
+
+        write_box_header_ext(writer, self.version, flags)?;
+
         writer.write_u32::<BigEndian>(self.track_id)?;
-        writer.write_u64::<BigEndian>(self.base_data_offset)?;
+
+        if let Some(val) = self.base_data_offset {
+            writer.write_u64::<BigEndian>(val)?;
+        }
+        if let Some(val) = self.sample_description_index {
+            writer.write_u32::<BigEndian>(val)?;
+        }
+        if let Some(val) = self.default_sample_duration {
+            writer.write_u32::<BigEndian>(val)?;
+        }
+        if let Some(val) = self.default_sample_size {
+            writer.write_u32::<BigEndian>(val)?;
+        }
+        if let Some(val) = self.default_sample_flags {
+            writer.write_u32::<BigEndian>(val)?;
+        }
 
         Ok(size)
     }
@@ -94,9 +211,14 @@ mod tests {
     fn test_tfhd() {
         let src_box = TfhdBox {
             version: 0,
-            flags: 0,
             track_id: 1,
-            base_data_offset: 0,
+            base_data_offset: Some(0),
+            sample_description_index: None,
+            default_sample_duration: None,
+            default_sample_size: None,
+            default_sample_flags: None,
+            duration_is_empty: false,
+            default_base_is_moof: false,
         };
         let mut buf = Vec::new();
         src_box.write_box(&mut buf).unwrap();

--- a/src/mp4box/traf.rs
+++ b/src/mp4box/traf.rs
@@ -1,12 +1,15 @@
+#[cfg(feature = "use_serde")]
+use serde::Serialize;
 use std::io::{Read, Seek, SeekFrom, Write};
-use serde::{Serialize};
 
 use crate::mp4box::*;
 use crate::mp4box::{tfhd::TfhdBox, trun::TrunBox};
 
-#[derive(Debug, Clone, PartialEq, Default, Serialize)]
+#[derive(Debug, Clone, PartialEq, Default)]
+#[cfg_attr(feature = "use_serde", derive(Serialize))]
 pub struct TrafBox {
     pub tfhd: TfhdBox,
+    pub tfdt: Option<TfdtBox>,
     pub trun: Option<TrunBox>,
 }
 
@@ -18,6 +21,9 @@ impl TrafBox {
     pub fn get_size(&self) -> u64 {
         let mut size = HEADER_SIZE;
         size += self.tfhd.box_size();
+        if let Some(ref tfdt) = self.tfdt {
+            size += tfdt.box_size();
+        }
         if let Some(ref trun) = self.trun {
             size += trun.box_size();
         }
@@ -34,6 +40,7 @@ impl Mp4Box for TrafBox {
         return self.get_size();
     }
 
+    #[cfg(feature = "use_serde")]
     fn to_json(&self) -> Result<String> {
         Ok(serde_json::to_string(&self).unwrap())
     }
@@ -50,6 +57,7 @@ impl<R: Read + Seek> ReadBox<&mut R> for TrafBox {
 
         let mut tfhd = None;
         let mut trun = None;
+        let mut tfdt = None;
 
         let mut current = reader.seek(SeekFrom::Current(0))?;
         let end = start + size;
@@ -65,8 +73,12 @@ impl<R: Read + Seek> ReadBox<&mut R> for TrafBox {
                 BoxType::TrunBox => {
                     trun = Some(TrunBox::read_box(reader, s)?);
                 }
+                BoxType::TfdtBox => {
+                    tfdt = Some(TfdtBox::read_box(reader, s)?);
+                }
                 _ => {
                     // XXX warn!()
+                    println!("WARNING: unexpected box {:?}", name);
                     skip_box(reader, s)?;
                 }
             }
@@ -82,6 +94,7 @@ impl<R: Read + Seek> ReadBox<&mut R> for TrafBox {
 
         Ok(TrafBox {
             tfhd: tfhd.unwrap(),
+            tfdt,
             trun,
         })
     }
@@ -93,6 +106,13 @@ impl<W: Write> WriteBox<&mut W> for TrafBox {
         BoxHeader::new(self.box_type(), size).write(writer)?;
 
         self.tfhd.write_box(writer)?;
+
+        if let Some(tfdt) = &self.tfdt {
+            tfdt.write_box(writer)?;
+        }
+        if let Some(trun) = &self.trun {
+            trun.write_box(writer)?;
+        }
 
         Ok(size)
     }

--- a/src/mp4box/trak.rs
+++ b/src/mp4box/trak.rs
@@ -1,14 +1,16 @@
+#[cfg(feature = "use_serde")]
+use serde::Serialize;
 use std::io::{Read, Seek, SeekFrom, Write};
-use serde::{Serialize};
 
 use crate::mp4box::*;
 use crate::mp4box::{edts::EdtsBox, mdia::MdiaBox, tkhd::TkhdBox};
 
-#[derive(Debug, Clone, PartialEq, Default, Serialize)]
+#[derive(Debug, Clone, PartialEq, Default)]
+#[cfg_attr(feature = "use_serde", derive(Serialize))]
 pub struct TrakBox {
     pub tkhd: TkhdBox,
 
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "use_serde", serde(skip_serializing_if = "Option::is_none"))]
     pub edts: Option<EdtsBox>,
 
     pub mdia: MdiaBox,
@@ -39,6 +41,7 @@ impl Mp4Box for TrakBox {
         return self.get_size();
     }
 
+    #[cfg(feature = "use_serde")]
     fn to_json(&self) -> Result<String> {
         Ok(serde_json::to_string(&self).unwrap())
     }

--- a/src/mp4box/trun.rs
+++ b/src/mp4box/trun.rs
@@ -1,18 +1,28 @@
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
+#[cfg(feature = "use_serde")]
+use serde::Serialize;
 use std::io::{Read, Seek, Write};
-use serde::{Serialize};
 
 use crate::mp4box::*;
+use crate::SampleFlags;
 
-#[derive(Debug, Clone, PartialEq, Default, Serialize)]
+#[cfg_attr(feature = "use_serde", derive(Serialize))]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct TrunBox {
     pub version: u8,
-    pub flags: u32,
     pub sample_count: u32,
-    pub data_offset: i32,
 
-    #[serde(skip_serializing)]
-    pub sample_sizes: Vec<u32>,
+    pub data_offset: Option<i32>,
+    pub first_sample_flags: Option<SampleFlags>,
+
+    #[cfg_attr(feature = "use_serde", serde(skip_serializing))]
+    pub sample_durations: Option<Vec<u32>>,
+    #[cfg_attr(feature = "use_serde", serde(skip_serializing))]
+    pub sample_sizes: Option<Vec<u32>>,
+    #[cfg_attr(feature = "use_serde", serde(skip_serializing))]
+    pub sample_flags: Option<Vec<SampleFlags>>,
+    #[cfg_attr(feature = "use_serde", serde(skip_serializing))]
+    pub sample_composition_time_offsets: Option<Vec<i64>>,
 }
 
 impl TrunBox {
@@ -21,7 +31,27 @@ impl TrunBox {
     }
 
     pub fn get_size(&self) -> u64 {
-        HEADER_SIZE + HEADER_EXT_SIZE + 8 + (4 * self.sample_sizes.len() as u64)
+        let mut size = HEADER_SIZE + HEADER_EXT_SIZE;
+        size += 4;
+        if self.data_offset.is_some() {
+            size += 4;
+        }
+        if self.first_sample_flags.is_some() {
+            size += 4;
+        }
+        if self.sample_durations.is_some() {
+            size += 4 * self.sample_count as u64;
+        }
+        if self.sample_sizes.is_some() {
+            size += 4 * self.sample_count as u64;
+        }
+        if self.sample_flags.is_some() {
+            size += 4 * self.sample_count as u64;
+        }
+        if self.sample_composition_time_offsets.is_some() {
+            size += 4 * self.sample_count as u64;
+        }
+        size
     }
 }
 
@@ -34,13 +64,13 @@ impl Mp4Box for TrunBox {
         return self.get_size();
     }
 
+    #[cfg(feature = "use_serde")]
     fn to_json(&self) -> Result<String> {
         Ok(serde_json::to_string(&self).unwrap())
     }
 
     fn summary(&self) -> Result<String> {
-        let s = format!("sample_size={}",
-            self.sample_count);
+        let s = format!("sample_size={}", self.sample_count);
         Ok(s)
     }
 }
@@ -51,23 +81,77 @@ impl<R: Read + Seek> ReadBox<&mut R> for TrunBox {
 
         let (version, flags) = read_box_header_ext(reader)?;
 
-        let sample_count = reader.read_u32::<BigEndian>()?;
-        let data_offset = reader.read_i32::<BigEndian>()?;
+        let data_offset_present = (flags & 0x000001) != 0;
+        let first_sample_flags_present = (flags & 0x000004) != 0;
+        let sample_duration_present = (flags & 0x000100) != 0;
+        let sample_size_present = (flags & 0x000200) != 0;
+        let sample_flags_present = (flags & 0x000400) != 0;
+        let sample_composition_time_offsets_present = (flags & 0x000800) != 0;
 
-        let mut sample_sizes = Vec::with_capacity(sample_count as usize);
+        let sample_count = reader.read_u32::<BigEndian>()?;
+
+        let data_offset = if data_offset_present {
+            Some(reader.read_i32::<BigEndian>()?)
+        } else {
+            None
+        };
+        let first_sample_flags = if first_sample_flags_present {
+            Some(SampleFlags::new(reader.read_u32::<BigEndian>()?))
+        } else {
+            None
+        };
+
+        let mut sample_durations = if sample_duration_present {
+            Some(Vec::with_capacity(sample_count as usize))
+        } else {
+            None
+        };
+        let mut sample_sizes = if sample_size_present {
+            Some(Vec::with_capacity(sample_count as usize))
+        } else {
+            None
+        };
+        let mut sample_flags = if sample_flags_present {
+            Some(Vec::with_capacity(sample_count as usize))
+        } else {
+            None
+        };
+        let mut sample_composition_time_offsets = if sample_composition_time_offsets_present {
+            Some(Vec::with_capacity(sample_count as usize))
+        } else {
+            None
+        };
+
         for _ in 0..sample_count {
-            let sample_size = reader.read_u32::<BigEndian>()?;
-            sample_sizes.push(sample_size);
+            if let Some(vec) = &mut sample_durations {
+                vec.push(reader.read_u32::<BigEndian>()?);
+            }
+            if let Some(vec) = &mut sample_sizes {
+                vec.push(reader.read_u32::<BigEndian>()?);
+            }
+            if let Some(vec) = &mut sample_flags {
+                vec.push(SampleFlags::new(reader.read_u32::<BigEndian>()?));
+            }
+            if let Some(vec) = &mut sample_composition_time_offsets {
+                if version == 0 {
+                    vec.push(reader.read_u32::<BigEndian>()?.into());
+                } else {
+                    vec.push(reader.read_i32::<BigEndian>()?.into());
+                }
+            }
         }
 
         skip_bytes_to(reader, start + size)?;
 
         Ok(TrunBox {
             version,
-            flags,
             sample_count,
             data_offset,
+            first_sample_flags,
+            sample_durations,
             sample_sizes,
+            sample_flags,
+            sample_composition_time_offsets,
         })
     }
 }
@@ -77,13 +161,57 @@ impl<W: Write> WriteBox<&mut W> for TrunBox {
         let size = self.box_size();
         BoxHeader::new(self.box_type(), size).write(writer)?;
 
-        write_box_header_ext(writer, self.version, self.flags)?;
+        let mut flags = 0;
+        if self.data_offset.is_some() {
+            flags |= 0x000001;
+        }
+        if self.first_sample_flags.is_some() {
+            flags |= 0x000004;
+        }
+        if let Some(vec) = &self.sample_durations {
+            assert_eq!(self.sample_count, vec.len() as u32);
+            flags |= 0x000100;
+        }
+        if let Some(vec) = &self.sample_sizes {
+            assert_eq!(self.sample_count, vec.len() as u32);
+            flags |= 0x000200;
+        }
+        if let Some(vec) = &self.sample_flags {
+            assert_eq!(self.sample_count, vec.len() as u32);
+            flags |= 0x000400;
+        }
+        if let Some(vec) = &self.sample_composition_time_offsets {
+            assert_eq!(self.sample_count, vec.len() as u32);
+            flags |= 0x000800;
+        }
+        write_box_header_ext(writer, self.version, flags)?;
 
         writer.write_u32::<BigEndian>(self.sample_count)?;
-        writer.write_i32::<BigEndian>(self.data_offset)?;
-        assert_eq!(self.sample_count, self.sample_sizes.len() as u32);
-        for sample_number in self.sample_sizes.iter() {
-            writer.write_u32::<BigEndian>(*sample_number)?;
+
+        if let Some(val) = self.data_offset {
+            writer.write_i32::<BigEndian>(val)?;
+        }
+        if let Some(val) = self.first_sample_flags {
+            writer.write_u32::<BigEndian>(val.to_u32())?;
+        }
+
+        for n in 0..(self.sample_count as usize) {
+            if let Some(vec) = &self.sample_durations {
+                writer.write_u32::<BigEndian>(vec[n])?;
+            }
+            if let Some(vec) = &self.sample_sizes {
+                writer.write_u32::<BigEndian>(vec[n])?;
+            }
+            if let Some(vec) = &self.sample_flags {
+                writer.write_u32::<BigEndian>(vec[n].to_u32())?;
+            }
+            if let Some(vec) = &self.sample_composition_time_offsets {
+                if self.version == 0 {
+                    writer.write_u32::<BigEndian>(vec[n].try_into().unwrap())?;
+                } else {
+                    writer.write_i32::<BigEndian>(vec[n].try_into().unwrap())?;
+                }
+            }
         }
 
         Ok(size)
@@ -100,10 +228,13 @@ mod tests {
     fn test_trun_same_size() {
         let src_box = TrunBox {
             version: 0,
-            flags: 0,
-            data_offset: 0,
             sample_count: 0,
-            sample_sizes: vec![],
+            data_offset: Some(0),
+            first_sample_flags: None,
+            sample_durations: None,
+            sample_sizes: Some(vec![]),
+            sample_flags: None,
+            sample_composition_time_offsets: None,
         };
         let mut buf = Vec::new();
         src_box.write_box(&mut buf).unwrap();
@@ -122,10 +253,13 @@ mod tests {
     fn test_trun_many_sizes() {
         let src_box = TrunBox {
             version: 0,
-            flags: 0,
-            data_offset: 0,
+            data_offset: Some(0),
+            first_sample_flags: None,
             sample_count: 9,
+            sample_durations: None,
             sample_sizes: vec![1165, 11, 11, 8545, 10126, 10866, 9643, 9351, 7730],
+            sample_flags: None,
+            sample_composition_time_offsets: None,
         };
         let mut buf = Vec::new();
         src_box.write_box(&mut buf).unwrap();

--- a/src/mp4box/tx3g.rs
+++ b/src/mp4box/tx3g.rs
@@ -1,10 +1,12 @@
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
+#[cfg(feature = "use_serde")]
+use serde::Serialize;
 use std::io::{Read, Seek, Write};
-use serde::{Serialize};
 
 use crate::mp4box::*;
 
-#[derive(Debug, Clone, PartialEq, Serialize)]
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "use_serde", derive(Serialize))]
 pub struct Tx3gBox {
     pub data_reference_index: u16,
     pub display_flags: u32,
@@ -15,12 +17,13 @@ pub struct Tx3gBox {
     pub style_record: [u8; 12],
 }
 
-#[derive(Debug, Clone, PartialEq, Default, Serialize)]
+#[derive(Debug, Clone, PartialEq, Default)]
+#[cfg_attr(feature = "use_serde", derive(Serialize))]
 pub struct RgbaColor {
     pub red: u8,
     pub green: u8,
     pub blue: u8,
-    pub alpha: u8
+    pub alpha: u8,
 }
 
 impl Default for Tx3gBox {
@@ -30,7 +33,7 @@ impl Default for Tx3gBox {
             display_flags: 0,
             horizontal_justification: 1,
             vertical_justification: -1,
-            bg_color_rgba: RgbaColor{
+            bg_color_rgba: RgbaColor {
                 red: 0,
                 green: 0,
                 blue: 0,
@@ -48,7 +51,7 @@ impl Tx3gBox {
     }
 
     pub fn get_size(&self) -> u64 {
-        HEADER_SIZE + 6 + 32 
+        HEADER_SIZE + 6 + 32
     }
 }
 
@@ -61,6 +64,7 @@ impl Mp4Box for Tx3gBox {
         return self.get_size();
     }
 
+    #[cfg(feature = "use_serde")]
     fn to_json(&self) -> Result<String> {
         Ok(serde_json::to_string(&self).unwrap())
     }
@@ -165,7 +169,7 @@ mod tests {
             display_flags: 0,
             horizontal_justification: 1,
             vertical_justification: -1,
-            bg_color_rgba: RgbaColor{
+            bg_color_rgba: RgbaColor {
                 red: 0,
                 green: 0,
                 blue: 0,

--- a/src/mp4box/vmhd.rs
+++ b/src/mp4box/vmhd.rs
@@ -1,10 +1,12 @@
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
+#[cfg(feature = "use_serde")]
+use serde::Serialize;
 use std::io::{Read, Seek, Write};
-use serde::{Serialize};
 
 use crate::mp4box::*;
 
-#[derive(Debug, Clone, PartialEq, Default, Serialize)]
+#[derive(Debug, Clone, PartialEq, Default)]
+#[cfg_attr(feature = "use_serde", derive(Serialize))]
 pub struct VmhdBox {
     pub version: u8,
     pub flags: u32,
@@ -12,11 +14,17 @@ pub struct VmhdBox {
     pub op_color: RgbColor,
 }
 
-#[derive(Debug, Clone, PartialEq, Default, Serialize)]
+#[derive(Debug, Clone, PartialEq, Default)]
+#[cfg_attr(feature = "use_serde", derive(Serialize))]
 pub struct RgbColor {
     pub red: u16,
     pub green: u16,
     pub blue: u16,
+}
+impl From<(u16, u16, u16)> for RgbColor {
+    fn from((red, green, blue): (u16, u16, u16)) -> Self {
+        RgbColor { red, green, blue }
+    }
 }
 
 impl VmhdBox {
@@ -38,16 +46,15 @@ impl Mp4Box for VmhdBox {
         return self.get_size();
     }
 
+    #[cfg(feature = "use_serde")]
     fn to_json(&self) -> Result<String> {
         Ok(serde_json::to_string(&self).unwrap())
     }
 
     fn summary(&self) -> Result<String> {
-        let s = format!("graphics_mode={} op_color={}{}{}",
-            self.graphics_mode,
-            self.op_color.red,
-            self.op_color.green,
-            self.op_color.blue
+        let s = format!(
+            "graphics_mode={} op_color={}{}{}",
+            self.graphics_mode, self.op_color.red, self.op_color.green, self.op_color.blue
         );
         Ok(s)
     }

--- a/src/sample_flags.rs
+++ b/src/sample_flags.rs
@@ -1,0 +1,172 @@
+#[cfg(feature = "use_serde")]
+use serde::Serialize;
+
+#[cfg_attr(feature = "use_serde", derive(Serialize))]
+#[cfg_attr(feature = "use_serde", serde(rename_all = "snake_case"))]
+#[derive(Debug, Copy, Clone, PartialEq)]
+#[repr(u8)]
+pub enum IsLeading {
+    Unknown = 0,
+    LeadingDep = 1,
+    NotLeading = 2,
+    Leading = 3,
+}
+impl Default for IsLeading {
+    fn default() -> Self {
+        IsLeading::Unknown
+    }
+}
+impl IsLeading {
+    pub fn is_unknown(&self) -> bool {
+        *self == Self::Unknown
+    }
+}
+
+#[cfg_attr(feature = "use_serde", derive(Serialize))]
+#[cfg_attr(feature = "use_serde", serde(rename_all = "snake_case"))]
+#[derive(Debug, Copy, Clone, PartialEq)]
+#[repr(u8)]
+pub enum DependsOn {
+    Unknown = 0,
+    Depends = 1,
+    NotDepends = 2,
+}
+impl Default for DependsOn {
+    fn default() -> Self {
+        DependsOn::Unknown
+    }
+}
+impl DependsOn {
+    pub fn is_unknown(&self) -> bool {
+        *self == Self::Unknown
+    }
+}
+
+#[cfg_attr(feature = "use_serde", derive(Serialize))]
+#[cfg_attr(feature = "use_serde", serde(rename_all = "snake_case"))]
+#[derive(Debug, Copy, Clone, PartialEq)]
+#[repr(u8)]
+pub enum DependedOn {
+    Unknown = 0,
+    Depended = 1,
+    NotDepended = 2,
+}
+impl Default for DependedOn {
+    fn default() -> Self {
+        DependedOn::Unknown
+    }
+}
+impl DependedOn {
+    pub fn is_unknown(&self) -> bool {
+        *self == Self::Unknown
+    }
+}
+
+#[cfg_attr(feature = "use_serde", derive(Serialize))]
+#[cfg_attr(feature = "use_serde", serde(rename_all = "snake_case"))]
+#[derive(Debug, Copy, Clone, PartialEq)]
+#[repr(u8)]
+pub enum HasRedundancy {
+    Unknown = 0,
+    Redundant = 1,
+    NotRedundant = 2,
+}
+impl Default for HasRedundancy {
+    fn default() -> Self {
+        HasRedundancy::Unknown
+    }
+}
+impl HasRedundancy {
+    pub fn is_unknown(&self) -> bool {
+        *self == Self::Unknown
+    }
+}
+
+#[cfg_attr(feature = "use_serde", derive(Serialize))]
+#[derive(Debug, Copy, Clone, PartialEq, Default)]
+pub struct SampleFlags {
+    #[cfg_attr(
+        feature = "use_serde",
+        serde(default, skip_serializing_if = "IsLeading::is_unknown")
+    )]
+    pub is_leading: IsLeading,
+    #[cfg_attr(
+        feature = "use_serde",
+        serde(default, skip_serializing_if = "DependsOn::is_unknown")
+    )]
+    pub depends_on: DependsOn,
+    #[cfg_attr(
+        feature = "use_serde",
+        serde(default, skip_serializing_if = "DependedOn::is_unknown")
+    )]
+    pub depended_on: DependedOn,
+    #[cfg_attr(
+        feature = "use_serde",
+        serde(default, skip_serializing_if = "HasRedundancy::is_unknown")
+    )]
+    pub has_redundancy: HasRedundancy,
+    pub padding_value: u8,
+    pub is_non_sync: bool,
+    pub degredation_priority: u16,
+}
+
+impl SampleFlags {
+    pub fn new(flags: u32) -> Self {
+        let is_leading = match (flags >> 26) & 0b11 {
+            0 => IsLeading::Unknown,
+            1 => IsLeading::LeadingDep,
+            2 => IsLeading::NotLeading,
+            3 => IsLeading::Leading,
+            _ => unreachable!(),
+        };
+
+        let depends_on = match (flags >> 24) & 0b11 {
+            0 => DependsOn::Unknown,
+            1 => DependsOn::Depends,
+            2 => DependsOn::NotDepends,
+            3 => panic!("got reserved"),
+            _ => unreachable!(),
+        };
+
+        let depended_on = match (flags >> 22) & 0b11 {
+            0 => DependedOn::Unknown,
+            1 => DependedOn::Depended,
+            2 => DependedOn::NotDepended,
+            3 => panic!("got reserved"),
+            _ => unreachable!(),
+        };
+
+        let has_redundancy = match (flags >> 20) & 0b11 {
+            0 => HasRedundancy::Unknown,
+            1 => HasRedundancy::Redundant,
+            2 => HasRedundancy::NotRedundant,
+            3 => panic!("got reserved"),
+            _ => unreachable!(),
+        };
+
+        let padding_value = ((flags >> 17) & 0b111) as u8;
+
+        let is_non_sync = (flags >> 16) != 0;
+
+        SampleFlags {
+            is_leading,
+            depends_on,
+            depended_on,
+            has_redundancy,
+            padding_value,
+            is_non_sync,
+            degredation_priority: flags as u16,
+        }
+    }
+    pub fn to_u32(&self) -> u32 {
+        let mut flags = 0;
+        flags |= (self.is_leading as u32) << 26;
+        flags |= (self.depends_on as u32) << 24;
+        flags |= (self.depended_on as u32) << 22;
+        flags |= (self.has_redundancy as u32) << 20;
+        flags |= (self.padding_value as u32 & 0b111) << 17;
+        flags |= (self.is_non_sync as u32) << 16;
+        flags |= self.degredation_priority as u32;
+        flags
+    }
+}


### PR DESCRIPTION
Sorry about the massive PR, this really started off with me having to make some small tweaks and blew up in size from there.

* Put serde dependency behind a feature flag
* Many fixed point numbers from the spec were previously interpreted as fractions, handle those as fixed point numbers instead. This also removes the dependency on `num-fractions`.
* Make a couple of boxes read and write their flags properly. Previously this would fail to read many mp4 files/write invalid mp4 because of this.
* A couple of boxes were missing readers and writers for some fields, this caused some browsers to fail to interpret the files because of invalid defaults.
* Support a few new boxes required for mp4 segments in browsers.
* Add a new `mp4tree` example that simply dumps the raw box tree.
* Expose box apis externally.
* Enable writing of `avc2` and `avc3` variants. Of particular interest is `avc3` which stores AVC SPS and PPS in the NAL stream instead of in a separate box.
* Probably many more small things.

I am writing mp4 segment files that work from a separate project, if it's wanted I can make a minimal example that writes a simple set of fragmented mp4 files.