### PR TITLE
Store 4 bytes in FourCC instead of a String

### DIFF
--- a/src/mp4box/ftyp.rs
+++ b/src/mp4box/ftyp.rs
@@ -95,23 +95,13 @@ mod tests {
     #[test]
     fn test_ftyp() {
         let src_box = FtypBox {
-            major_brand: FourCC {
-                value: String::from("isom"),
-            },
+            major_brand: str::parse("isom").unwrap(),
             minor_version: 0,
             compatible_brands: vec![
-                FourCC {
-                    value: String::from("isom"),
-                },
-                FourCC {
-                    value: String::from("iso2"),
-                },
-                FourCC {
-                    value: String::from("avc1"),
-                },
-                FourCC {
-                    value: String::from("mp41"),
-                },
+                str::parse("isom").unwrap(),
+                str::parse("iso2").unwrap(),
+                str::parse("avc1").unwrap(),
+                str::parse("mp41").unwrap(),
             ],
         };
         let mut buf = Vec::new();

--- a/src/mp4box/hdlr.rs
+++ b/src/mp4box/hdlr.rs
@@ -108,7 +108,7 @@ mod tests {
         let src_box = HdlrBox {
             version: 0,
             flags: 0,
-            handler_type: FourCC::from("vide"),
+            handler_type: str::parse::<FourCC>("vide").unwrap(),
             name: String::from("VideoHandler"),
         };
         let mut buf = Vec::new();

--- a/src/mp4box/mod.rs
+++ b/src/mp4box/mod.rs
@@ -342,7 +342,7 @@ mod tests {
     fn test_fourcc() {
         let ftyp_fcc = 0x66747970;
         let ftyp_value = FourCC::from(ftyp_fcc);
-        assert_eq!(ftyp_value.value, "ftyp");
+        assert_eq!(&ftyp_value.value[..], b"ftyp");
         let ftyp_fcc2: u32 = ftyp_value.into();
         assert_eq!(ftyp_fcc, ftyp_fcc2);
     }


### PR DESCRIPTION
String to FourCC now must go through `str::parse` and is fallible in case the string contains less than four bytes.