### PR TITLE
Attempt to minimize assertions in non-test code

### DIFF
--- a/src/mp4box/dinf.rs
+++ b/src/mp4box/dinf.rs
@@ -260,7 +260,9 @@ impl<R: Read + Seek> ReadBox<&mut R> for UrlBox {
             reader.read_exact(&mut buf)?;
             match String::from_utf8(buf) {
                 Ok(t) => {
-                    assert_eq!(t.len(), buf_size as usize);
+                    if t.len() != buf_size as usize {
+                        return Err(Error::InvalidData("string too small"))
+                    }
                     t
                 }
                 _ => String::default(),

--- a/src/mp4box/elst.rs
+++ b/src/mp4box/elst.rs
@@ -30,8 +30,7 @@ impl ElstBox {
         let mut size = HEADER_SIZE + HEADER_EXT_SIZE + 4;
         if self.version == 1 {
             size += self.entries.len() as u64 * 20;
-        } else {
-            assert_eq!(self.version, 0);
+        } else if self.version == 0 {
             size += self.entries.len() as u64 * 12;
         }
         size

--- a/src/mp4box/hdlr.rs
+++ b/src/mp4box/hdlr.rs
@@ -58,7 +58,9 @@ impl<R: Read + Seek> ReadBox<&mut R> for HdlrBox {
 
         let handler_string = match String::from_utf8(buf) {
             Ok(t) => {
-                assert_eq!(t.len(), buf_size as usize);
+                if t.len() != buf_size as usize {
+                    return Err(Error::InvalidData("string too small"))
+                }
                 t
             }
             _ => String::from("null"),

--- a/src/mp4box/mehd.rs
+++ b/src/mp4box/mehd.rs
@@ -21,8 +21,7 @@ impl MehdBox {
 
         if self.version == 1 {
             size += 8;
-        } else {
-            assert_eq!(self.version, 0);
+        } else if self.version == 0 {
             size += 4;
         }
         size
@@ -66,9 +65,10 @@ impl<R: Read + Seek> ReadBox<&mut R> for MehdBox {
 
         let fragment_duration = if version == 1 {
             reader.read_u64::<BigEndian>()?
-        } else {
-            assert_eq!(version, 0);
+        } else if version == 0 {
             reader.read_u32::<BigEndian>()? as u64
+        } else {
+            return Err(Error::InvalidData("version must be 0 or 1"));
         };
         skip_bytes_to(reader, start + size)?;
 
@@ -89,9 +89,10 @@ impl<W: Write> WriteBox<&mut W> for MehdBox {
 
         if self.version == 1 {
             writer.write_u64::<BigEndian>(self.fragment_duration)?;
-        } else {
-            assert_eq!(self.version, 0);
+        } else if self.version == 0 {
             writer.write_u32::<BigEndian>(self.fragment_duration as u32)?;
+        } else {
+            return Err(Error::InvalidData("version must be 0 or 1"));
         }
 
         Ok(size)

--- a/src/mp4box/stsz.rs
+++ b/src/mp4box/stsz.rs
@@ -83,7 +83,9 @@ impl<W: Write> WriteBox<&mut W> for StszBox {
         writer.write_u32::<BigEndian>(self.sample_size)?;
         writer.write_u32::<BigEndian>(self.sample_count)?;
         if self.sample_size == 0 {
-            assert_eq!(self.sample_count, self.sample_sizes.len() as u32);
+            if self.sample_count != self.sample_sizes.len() as u32 {
+                return Err(Error::InvalidData("sample count out of sync"));
+            }
             for sample_number in self.sample_sizes.iter() {
                 writer.write_u32::<BigEndian>(*sample_number)?;
             }

--- a/src/mp4box/trun.rs
+++ b/src/mp4box/trun.rs
@@ -154,7 +154,9 @@ impl<W: Write> WriteBox<&mut W> for TrunBox {
         if let Some(v) = self.first_sample_flags {
             writer.write_u32::<BigEndian>(v)?;
         }
-        assert_eq!(self.sample_count, self.sample_sizes.len() as u32);
+        if self.sample_count != self.sample_sizes.len() as u32 {
+            return Err(Error::InvalidData("sample count out of sync"));
+        }
         for i in 0..self.sample_count as usize {
             if TrunBox::FLAG_SAMPLE_DURATION & self.flags > 0 {
                 writer.write_u32::<BigEndian>(self.sample_durations[i])?;

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -66,7 +66,9 @@ impl<R: Read + Seek> Mp4Reader<R> {
         let mut tracks = if let Some(ref moov) = moov {
             let mut tracks = Vec::with_capacity(moov.traks.len());
             for (i, trak) in moov.traks.iter().enumerate() {
-                assert_eq!(trak.tkhd.track_id, i as u32 + 1);
+                if trak.tkhd.track_id != i as u32 + 1 {
+                    return Err(Error::InvalidData("tracks out of order"));
+                }
                 tracks.push(Mp4Track::from(trak));
             }
             tracks

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -116,7 +116,9 @@ impl<W: Write + Seek> Mp4Writer<W> {
     fn update_mdat_size(&mut self) -> Result<()> {
         let mdat_end = self.writer.seek(SeekFrom::Current(0))?;
         let mdat_size = mdat_end - self.mdat_pos;
-        assert!(mdat_size < std::u32::MAX as u64);
+        if mdat_size > std::u32::MAX as u64 {
+            return Err(Error::InvalidData("mdat size too large"));
+        }
         self.writer.seek(SeekFrom::Start(self.mdat_pos))?;
         self.writer.write_u32::<BigEndian>(mdat_size as u32)?;
         self.writer.seek(SeekFrom::Start(mdat_end))?;


### PR DESCRIPTION
Initial effort to reduce or eliminate the use of assertions in the production code (see issue 55). I'm certain these changes will need refinement, this is just a first pass. Not all of the changes were as simple as returning an `Err`, since some functions did not return a `Result`. Also, the error type used (`InvalidData`) is just a catch-all with a message, and in some cases a more refined error type may be in order.