### PR TITLE
expose all box types

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,7 +78,7 @@ mod types;
 pub use types::*;
 
 mod mp4box;
-pub use mp4box::{Mp4Box};
+pub use mp4box::*;
 
 mod track;
 pub use track::{Mp4Track, TrackConfig};


### PR DESCRIPTION
Instead of only exposing Mp4Box type, expose all box types to consumers.