### PR TITLE
upgrade dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,8 @@ license = "MIT"
 [dependencies]
 thiserror = "^1.0"
 byteorder = "1"
-bytes = "0.5"
-num-rational = { version = "0.3", features = ["serde"] }
+bytes = "1.1.0"
+num-rational = { version = "0.4.0", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 


### PR DESCRIPTION
Ensuring that projects that depend on this crate don't include old or potentially semver-incompatible versions of crates.
bytes 0.5 -> 1.1.0
num-rational 0.3 -> 0.4.0
I ran `cargo test` and everything still passed. 
Is there a plan to release a `version = "0.9.1"` patch version of this crate (if no breaking changes were made since the last release) in the near future?

