### PR TITLE
Mp4Writer should use co64 by default, then convert to stco is possible for compatibility

### DIFF
--- a/src/mp4box/stco.rs
+++ b/src/mp4box/stco.rs
@@ -1,6 +1,6 @@
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
+use serde::Serialize;
 use std::io::{Read, Seek, Write};
-use serde::{Serialize};
 
 use crate::mp4box::*;
 
@@ -78,6 +78,24 @@ impl<W: Write> WriteBox<&mut W> for StcoBox {
         }
 
         Ok(size)
+    }
+}
+
+impl std::convert::TryFrom<&co64::Co64Box> for StcoBox {
+    type Error = std::num::TryFromIntError;
+
+    fn try_from(co64: &co64::Co64Box) -> std::result::Result<Self, Self::Error> {
+        let entries = co64
+            .entries
+            .iter()
+            .copied()
+            .map(|x| u32::try_from(x))
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        Ok(Self {
+            version: 0,
+            flags: 0,
+            entries,
+        })
     }
 }
 


### PR DESCRIPTION
This change allows Mp4Writer to support writing mp4 files that are larger than 4GB. Previously the Chunk Offset Atom was used exclusively, so if you built an MP4 file that was larger than 4GB, the Chunk Offset Atom was silently corrupted. This change uses the co64 atom by default, and then checks for stco compatibility at the end of the track write. If all the offsets are under the 2^32 limit, then a stco atom is written, otherwise a co60 atom is written. 