### PR TITLE
Set mvhd/tkhd/mdhd version to 1 if duration is greater than u32::MAX

### DIFF
--- a/src/track.rs
+++ b/src/track.rs
@@ -724,8 +724,14 @@ impl Mp4TrackWriter {
 
     fn update_durations(&mut self, dur: u32, movie_timescale: u32) {
         self.trak.mdia.mdhd.duration += dur as u64;
+        if self.trak.mdia.mdhd.duration > (u32::MAX as u64) {
+            self.trak.mdia.mdhd.version = 1
+        }
         self.trak.tkhd.duration +=
             dur as u64 * movie_timescale as u64 / self.trak.mdia.mdhd.timescale as u64;
+        if self.trak.tkhd.duration > (u32::MAX as u64) {
+            self.trak.tkhd.version = 1
+        }
     }
 
     pub(crate) fn write_sample<W: Write + Seek>(

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -135,6 +135,9 @@ impl<W: Write + Seek> Mp4Writer<W> {
 
         moov.mvhd.timescale = self.timescale;
         moov.mvhd.duration = self.duration;
+        if moov.mvhd.duration > (u32::MAX as u64) {
+            moov.mvhd.version = 1
+        }
         moov.write_box(&mut self.writer)?;
         Ok(())
     }


### PR DESCRIPTION
Currently the version of the `mvhd`, `tkhd`, and `mdhd` boxes default to 0 in the mp4 writer. This can be an issue if the duration of a track, as defined by the timescale, exceeds u32::MAX. If u32::MAX is exceeded, the duration will end up corrupted as the upper bytes are just truncated. 

Alternatively, maybe the library should fail writing boxes when fields would overflow?