### PR TITLE
fix clippy & enhance CI/CD

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,8 +13,38 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Build
-      run: cargo build --verbose
-    - name: Run tests
-      run: cargo test --verbose
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+          components: rustfmt, clippy
+
+      - name: Setup rust smart caching
+        uses: Swatinem/rust-cache@v1.3.0
+
+      - name: Cargo fmt
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check
+
+      - name: Cargo clippy
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --no-deps -- -D warnings
+      
+      - name: Cargo build
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+      
+      - name: Cargo test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test

--- a/examples/mp4dump.rs
+++ b/examples/mp4dump.rs
@@ -45,12 +45,11 @@ fn get_boxes(file: File) -> Result<Vec<Box>> {
     let mp4 = mp4::Mp4Reader::read_header(reader, size)?;
 
     // collect known boxes
-    let mut boxes = Vec::new();
-
-    // ftyp, moov, mvhd
-    boxes.push(build_box(&mp4.ftyp));
-    boxes.push(build_box(&mp4.moov));
-    boxes.push(build_box(&mp4.moov.mvhd));
+    let mut boxes = vec![
+        build_box(&mp4.ftyp),
+        build_box(&mp4.moov),
+        build_box(&mp4.moov.mvhd),
+    ];
 
     if let Some(ref mvex) = &mp4.moov.mvex {
         boxes.push(build_box(mvex));

--- a/src/mp4box/avc1.rs
+++ b/src/mp4box/avc1.rs
@@ -283,13 +283,13 @@ impl NalUnit {
     fn read<R: Read + Seek>(reader: &mut R) -> Result<Self> {
         let length = reader.read_u16::<BigEndian>()? as usize;
         let mut bytes = vec![0u8; length];
-        reader.read(&mut bytes)?;
+        reader.read_exact(&mut bytes)?;
         Ok(NalUnit { bytes })
     }
 
     fn write<W: Write>(&self, writer: &mut W) -> Result<u64> {
         writer.write_u16::<BigEndian>(self.bytes.len() as u16)?;
-        writer.write(&self.bytes)?;
+        writer.write_all(&self.bytes)?;
         Ok(self.size() as u64)
     }
 }

--- a/src/mp4box/dinf.rs
+++ b/src/mp4box/dinf.rs
@@ -289,7 +289,7 @@ impl<W: Write> WriteBox<&mut W> for UrlBox {
         write_box_header_ext(writer, self.version, self.flags)?;
 
         if !self.location.is_empty() {
-            writer.write(self.location.as_bytes())?;
+            writer.write_all(self.location.as_bytes())?;
             writer.write_u8(0)?;
         }
 

--- a/src/mp4box/edts.rs
+++ b/src/mp4box/edts.rs
@@ -55,12 +55,9 @@ impl<R: Read + Seek> ReadBox<&mut R> for EdtsBox {
         let header = BoxHeader::read(reader)?;
         let BoxHeader { name, size: s } = header;
 
-        match name {
-            BoxType::ElstBox => {
-                let elst = ElstBox::read_box(reader, s)?;
-                edts.elst = Some(elst);
-            }
-            _ => {}
+        if let BoxType::ElstBox = name {
+            let elst = ElstBox::read_box(reader, s)?;
+            edts.elst = Some(elst);
         }
 
         skip_bytes_to(reader, start + size)?;

--- a/src/mp4box/hdlr.rs
+++ b/src/mp4box/hdlr.rs
@@ -92,7 +92,7 @@ impl<W: Write> WriteBox<&mut W> for HdlrBox {
             writer.write_u32::<BigEndian>(0)?;
         }
 
-        writer.write(self.name.as_bytes())?;
+        writer.write_all(self.name.as_bytes())?;
         writer.write_u8(0)?;
 
         Ok(size)

--- a/src/mp4box/mehd.rs
+++ b/src/mp4box/mehd.rs
@@ -4,7 +4,7 @@ use std::io::{Read, Seek, Write};
 
 use crate::mp4box::*;
 
-#[derive(Debug, Clone, PartialEq, Serialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Default)]
 pub struct MehdBox {
     pub version: u8,
     pub flags: u32,
@@ -25,16 +25,6 @@ impl MehdBox {
             size += 4;
         }
         size
-    }
-}
-
-impl Default for MehdBox {
-    fn default() -> Self {
-        MehdBox {
-            version: 0,
-            flags: 0,
-            fragment_duration: 0,
-        }
     }
 }
 

--- a/src/mp4box/mod.rs
+++ b/src/mp4box/mod.rs
@@ -212,7 +212,7 @@ impl BoxHeader {
     pub fn read<R: Read>(reader: &mut R) -> Result<Self> {
         // Create and read to buf.
         let mut buf = [0u8; 8]; // 8 bytes for box header.
-        reader.read(&mut buf)?;
+        reader.read_exact(&mut buf)?;
 
         // Get size.
         let s = buf[0..4].try_into().unwrap();
@@ -224,7 +224,7 @@ impl BoxHeader {
 
         // Get largesize if size is 1
         if size == 1 {
-            reader.read(&mut buf)?;
+            reader.read_exact(&mut buf)?;
             let s = buf.try_into().unwrap();
             let largesize = u64::from_be_bytes(s);
 

--- a/src/mp4box/mod.rs
+++ b/src/mp4box/mod.rs
@@ -122,9 +122,9 @@ macro_rules! boxtype {
             }
         }
 
-        impl Into<u32> for BoxType {
-            fn into(self) -> u32 {
-                match self {
+        impl From<BoxType> for u32 {
+            fn from(b: BoxType) -> u32 {
+                match b {
                     $( BoxType::$name => $value, )*
                     BoxType::UnknownBox(t) => t,
                 }
@@ -225,8 +225,7 @@ impl BoxHeader {
         // Get largesize if size is 1
         if size == 1 {
             reader.read_exact(&mut buf)?;
-            let s = buf.try_into().unwrap();
-            let largesize = u64::from_be_bytes(s);
+            let largesize = u64::from_be_bytes(buf);
 
             Ok(BoxHeader {
                 name: BoxType::from(typ),

--- a/src/mp4box/tfhd.rs
+++ b/src/mp4box/tfhd.rs
@@ -4,23 +4,12 @@ use std::io::{Read, Seek, Write};
 
 use crate::mp4box::*;
 
-#[derive(Debug, Clone, PartialEq, Serialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Default)]
 pub struct TfhdBox {
     pub version: u8,
     pub flags: u32,
     pub track_id: u32,
     pub base_data_offset: u64,
-}
-
-impl Default for TfhdBox {
-    fn default() -> Self {
-        TfhdBox {
-            version: 0,
-            flags: 0,
-            track_id: 0,
-            base_data_offset: 0,
-        }
-    }
 }
 
 impl TfhdBox {

--- a/src/track.rs
+++ b/src/track.rs
@@ -502,10 +502,7 @@ impl Mp4Track {
         }
 
         if let Some(ref stss) = self.trak.mdia.minf.stbl.stss {
-            match stss.entries.binary_search(&sample_id) {
-                Ok(_) => true,
-                Err(_) => false,
-            }
+            stss.entries.binary_search(&sample_id).is_ok()
         } else {
             true
         }

--- a/src/types.rs
+++ b/src/types.rs
@@ -206,9 +206,9 @@ impl TryFrom<&FourCC> for TrackType {
     }
 }
 
-impl Into<FourCC> for TrackType {
-    fn into(self) -> FourCC {
-        match self {
+impl From<TrackType> for FourCC {
+    fn from(t: TrackType) -> FourCC {
+        match t {
             TrackType::Video => HANDLER_TYPE_VIDEO_FOURCC.into(),
             TrackType::Audio => HANDLER_TYPE_AUDIO_FOURCC.into(),
             TrackType::Subtitle => HANDLER_TYPE_SUBTITLE_FOURCC.into(),
@@ -252,9 +252,9 @@ impl TryFrom<&str> for MediaType {
     }
 }
 
-impl Into<&str> for MediaType {
-    fn into(self) -> &'static str {
-        match self {
+impl From<MediaType> for &str {
+    fn from(t: MediaType) -> &'static str {
+        match t {
             MediaType::H264 => MEDIA_TYPE_H264,
             MediaType::H265 => MEDIA_TYPE_H265,
             MediaType::VP9 => MEDIA_TYPE_VP9,
@@ -264,9 +264,9 @@ impl Into<&str> for MediaType {
     }
 }
 
-impl Into<&str> for &MediaType {
-    fn into(self) -> &'static str {
-        match self {
+impl From<&MediaType> for &str {
+    fn from(t: &MediaType) -> &'static str {
+        match t {
             MediaType::H264 => MEDIA_TYPE_H264,
             MediaType::H265 => MEDIA_TYPE_H265,
             MediaType::VP9 => MEDIA_TYPE_VP9,
@@ -503,20 +503,20 @@ impl TryFrom<u8> for SampleFreqIndex {
 
 impl SampleFreqIndex {
     pub fn freq(&self) -> u32 {
-        match self {
-            &SampleFreqIndex::Freq96000 => 96000,
-            &SampleFreqIndex::Freq88200 => 88200,
-            &SampleFreqIndex::Freq64000 => 64000,
-            &SampleFreqIndex::Freq48000 => 48000,
-            &SampleFreqIndex::Freq44100 => 44100,
-            &SampleFreqIndex::Freq32000 => 32000,
-            &SampleFreqIndex::Freq24000 => 24000,
-            &SampleFreqIndex::Freq22050 => 22050,
-            &SampleFreqIndex::Freq16000 => 16000,
-            &SampleFreqIndex::Freq12000 => 12000,
-            &SampleFreqIndex::Freq11025 => 11025,
-            &SampleFreqIndex::Freq8000 => 8000,
-            &SampleFreqIndex::Freq7350 => 7350,
+        match *self {
+            SampleFreqIndex::Freq96000 => 96000,
+            SampleFreqIndex::Freq88200 => 88200,
+            SampleFreqIndex::Freq64000 => 64000,
+            SampleFreqIndex::Freq48000 => 48000,
+            SampleFreqIndex::Freq44100 => 44100,
+            SampleFreqIndex::Freq32000 => 32000,
+            SampleFreqIndex::Freq24000 => 24000,
+            SampleFreqIndex::Freq22050 => 22050,
+            SampleFreqIndex::Freq16000 => 16000,
+            SampleFreqIndex::Freq12000 => 12000,
+            SampleFreqIndex::Freq11025 => 11025,
+            SampleFreqIndex::Freq8000 => 8000,
+            SampleFreqIndex::Freq7350 => 7350,
         }
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -290,7 +290,7 @@ impl TryFrom<(u8, u8)> for AvcProfile {
     type Error = Error;
     fn try_from(value: (u8, u8)) -> Result<AvcProfile> {
         let profile = value.0;
-        let constraint_set1_flag = value.1 & 0x40 >> 7;
+        let constraint_set1_flag = (value.1 & 0x40) >> 7;
         match (profile, constraint_set1_flag) {
             (66, 1) => Ok(AvcProfile::AvcConstrainedBaseline),
             (66, 0) => Ok(AvcProfile::AvcBaseline),

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -24,7 +24,7 @@ fn test_read_mp4() {
 
     for b in brands {
         let t = mp4.compatible_brands().iter().any(|x| x.to_string() == b);
-        assert_eq!(t, true);
+        assert!(t);
     }
 
     assert_eq!(mp4.duration(), Duration::from_millis(62));


### PR DESCRIPTION
This PR fixes clippy errors and enhance the CI/CD with clippy checks and running latest rust version.

I would recommend to have a deep look at commit `fix clippy::unused_io_amount` : it allowed to fix a bug in `mp4a` parsing, where `BoxHeader::read` errors were silently ignored and could lead to "overflow read". But now the change could make `mp4` returns an error in some cases where it did not and could break existing code based on this bad behavior.

Up to you to release it as a breaking change release or not. 

Last I would recommend to check whether my fix for `fix clippy error with always 0 value` is correct. There was truly a bug, but I am not completely sure my fix is the one expected.

Cheers.