### PR TITLE
fix "mdat size too large"

### DIFF
--- a/src/mp4box/mod.rs
+++ b/src/mp4box/mod.rs
@@ -194,7 +194,8 @@ boxtype! {
     NameBox => 0xa96e616d,
     DayBox => 0xa9646179,
     CovrBox => 0x636f7672,
-    DescBox => 0x64657363
+    DescBox => 0x64657363,
+    WideBox => 0x77696465
 }
 
 pub trait Mp4Box: Sized {

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -71,6 +71,7 @@ impl<W: Write + Seek> Mp4Writer<W> {
         // TODO largesize
         let mdat_pos = writer.seek(SeekFrom::Current(0))?;
         BoxHeader::new(BoxType::MdatBox, HEADER_SIZE).write(&mut writer)?;
+        BoxHeader::new(BoxType::WideBox, HEADER_SIZE).write(&mut writer)?;
 
         let tracks = Vec::new();
         let timescale = config.timescale;
@@ -117,10 +118,14 @@ impl<W: Write + Seek> Mp4Writer<W> {
         let mdat_end = self.writer.seek(SeekFrom::Current(0))?;
         let mdat_size = mdat_end - self.mdat_pos;
         if mdat_size > std::u32::MAX as u64 {
-            return Err(Error::InvalidData("mdat size too large"));
+            self.writer.seek(SeekFrom::Start(self.mdat_pos))?;
+            self.writer.write_u32::<BigEndian>(1 as u32)?;
+            self.writer.seek(SeekFrom::Start(self.mdat_pos + 8))?;
+            self.writer.write_u64::<BigEndian>(mdat_size)?;
+        } else {
+            self.writer.seek(SeekFrom::Start(self.mdat_pos))?;
+            self.writer.write_u32::<BigEndian>(mdat_size as u32)?;
         }
-        self.writer.seek(SeekFrom::Start(self.mdat_pos))?;
-        self.writer.write_u32::<BigEndian>(mdat_size as u32)?;
         self.writer.seek(SeekFrom::Start(mdat_end))?;
         Ok(())
     }


### PR DESCRIPTION
use 'wide' atom as a place holder to fix  "mdat size too large" problem in writer.rs.

"Extended Size
If the size field of an atom is set to 1, the type field is followed by a 64-bit extended size field, which contains the actual size of the atom as a 64-bit unsigned integer. This is used when the size of a media data atom exceeds 2^32 bytes.

When the size field contains the actual size of the atom, the extended size field is not present. This means that when a QuickTime atom is modified by adding data, and its size crosses the 2^32 byte limit, there is no extended size field in which to record the new atom size. Consequently, it is not always possible to enlarge an atom beyond 2^32 bytes without copying its contents to a new atom.

To prevent this inconvenience, media data atoms are typically created with a 64-bit placeholder atom immediately preceding them in the movie file. The placeholder atom has a type of kWideAtomPlaceholderType ('wide').

Much like a 'free' or 'skip' atom, the 'wide' atom is reserved space, but in this case the space is reserved for a specific purpose. If a 'wide' atom immediately precedes a second atom, the second atom can be extended from a 32-bit size to a 64-bit size simply by starting the atom header 8 bytes earlier (overwriting the 'wide' atom), setting the size field to 1, and adding an extended size field. This way the offsets for sample data do not need to be recalculated.

The 'wide' atom is exactly 8 bytes in size, and consists solely of its size and type fields. It contains no other data."

---- https://developer.apple.com/library/archive/documentation/QuickTime/QTFF/QTFFChap1/qtff1.html#//apple_ref/doc/uid/TP40000939-CH203-BBCGDDDF