### PR TITLE
when writing, mdat box is always large

### DIFF
--- a/src/mp4box/mod.rs
+++ b/src/mp4box/mod.rs
@@ -110,7 +110,7 @@ pub use moof::MoofBox;
 pub use moov::MoovBox;
 
 pub const HEADER_SIZE: u64 = 8;
-// const HEADER_LARGE_SIZE: u64 = 16;
+pub const HEADER_LARGE_SIZE: u64 = 16;
 pub const HEADER_EXT_SIZE: u64 = 4;
 
 macro_rules! boxtype {
@@ -265,6 +265,13 @@ impl BoxHeader {
             writer.write_u32::<BigEndian>(self.name.into())?;
             Ok(8)
         }
+    }
+
+    pub fn write_large<W: Write>(&self, writer: &mut W) -> Result<u64> {
+        writer.write_u32::<BigEndian>(1)?;
+        writer.write_u32::<BigEndian>(self.name.into())?;
+        writer.write_u64::<BigEndian>(self.size)?;
+        Ok(16)
     }
 }
 

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -68,9 +68,8 @@ impl<W: Write + Seek> Mp4Writer<W> {
         };
         ftyp.write_box(&mut writer)?;
 
-        // TODO largesize
         let mdat_pos = writer.seek(SeekFrom::Current(0))?;
-        BoxHeader::new(BoxType::MdatBox, HEADER_SIZE).write(&mut writer)?;
+        BoxHeader::new(BoxType::MdatBox, HEADER_LARGE_SIZE).write_large(&mut writer)?;
 
         let tracks = Vec::new();
         let timescale = config.timescale;
@@ -116,11 +115,8 @@ impl<W: Write + Seek> Mp4Writer<W> {
     fn update_mdat_size(&mut self) -> Result<()> {
         let mdat_end = self.writer.seek(SeekFrom::Current(0))?;
         let mdat_size = mdat_end - self.mdat_pos;
-        if mdat_size > std::u32::MAX as u64 {
-            return Err(Error::InvalidData("mdat size too large"));
-        }
-        self.writer.seek(SeekFrom::Start(self.mdat_pos))?;
-        self.writer.write_u32::<BigEndian>(mdat_size as u32)?;
+        self.writer.seek(SeekFrom::Start(self.mdat_pos + 8))?;
+        self.writer.write_u64::<BigEndian>(mdat_size)?;
         self.writer.seek(SeekFrom::Start(mdat_end))?;
         Ok(())
     }


### PR DESCRIPTION
This adds 8 bytes per file but allows files > 4GB.

I wrote this independently of https://github.com/alfg/mp4-rust/pull/80 which I just noticed now.