### PR TITLE
Don't subtract overflow when 64-bit box size is less than 8

### DIFF
--- a/src/mp4box/mod.rs
+++ b/src/mp4box/mod.rs
@@ -245,9 +245,15 @@ impl BoxHeader {
 
             Ok(BoxHeader {
                 name: BoxType::from(typ),
-                size: largesize
-                    .checked_sub(HEADER_SIZE)
-                    .ok_or(Error::InvalidData("64-bit box size too small"))?,
+
+                // Subtract the length of the serialized largesize, as callers assume `size - HEADER_SIZE` is the length
+                // of the box data. Disallow `largesize < 16`, or else a largesize of 8 will result in a BoxHeader::size
+                // of 0, incorrectly indicating that the box data extends to the end of the stream.
+                size: match largesize {
+                    0 => 0,
+                    1..=15 => return Err(Error::InvalidData("64-bit box size too small")),
+                    16..=u64::MAX => largesize - 8,
+                },
             })
         } else {
             Ok(BoxHeader {
@@ -367,13 +373,19 @@ mod tests {
 
     #[test]
     fn test_zero_largesize() {
-        let header = BoxHeader::read(&mut &[0, 0, 0, 1, 1, 2, 3, 4, 0, 0, 0, 0, 0, 0, 0, 8][..]);
-        assert!(matches!(header, Ok(BoxHeader { size: 0, .. })));
+        let error = BoxHeader::read(&mut &[0, 0, 0, 1, 1, 2, 3, 4, 0, 0, 0, 0, 0, 0, 0, 8][..]);
+        assert!(matches!(error, Err(Error::InvalidData(_))));
     }
 
     #[test]
-    fn test_nonzero_largesize() {
-        let header = BoxHeader::read(&mut &[0, 0, 0, 1, 1, 2, 3, 4, 0, 0, 0, 0, 0, 0, 0, 9][..]);
-        assert!(matches!(header, Ok(BoxHeader { size: 1, .. })));
+    fn test_nonzero_largesize_too_small() {
+        let error = BoxHeader::read(&mut &[0, 0, 0, 1, 1, 2, 3, 4, 0, 0, 0, 0, 0, 0, 0, 15][..]);
+        assert!(matches!(error, Err(Error::InvalidData(_))));
+    }
+
+    #[test]
+    fn test_valid_largesize() {
+        let header = BoxHeader::read(&mut &[0, 0, 0, 1, 1, 2, 3, 4, 0, 0, 0, 0, 0, 0, 0, 16][..]);
+        assert!(matches!(header, Ok(BoxHeader { size: 8, .. })));
     }
 }


### PR DESCRIPTION
The subtraction overflow will cause a panic when overflow panics are enabled. It seems more robust to return an error instead. The 64-bit box size can only be this small in malformed files, but I'm working on a project to parse and sanitize untrusted MP4 using this library, and hopefully panics can be reserved for code bugs rather than malformed input.