### PR TITLE
Fix several overflows in box and track processing

### DIFF
--- a/src/mp4box/avc1.rs
+++ b/src/mp4box/avc1.rs
@@ -103,6 +103,11 @@ impl<R: Read + Seek> ReadBox<&mut R> for Avc1Box {
 
         let header = BoxHeader::read(reader)?;
         let BoxHeader { name, size: s } = header;
+        if s > size {
+            return Err(Error::InvalidData(
+                "avc1 box contains a box with a larger size than it",
+            ));
+        }
         if name == BoxType::AvcCBox {
             let avcc = AvcCBox::read_box(reader, s)?;
 

--- a/src/mp4box/co64.rs
+++ b/src/mp4box/co64.rs
@@ -49,6 +49,11 @@ impl<R: Read + Seek> ReadBox<&mut R> for Co64Box {
         let (version, flags) = read_box_header_ext(reader)?;
 
         let entry_count = reader.read_u32::<BigEndian>()?;
+        if u64::from(entry_count) > size.saturating_sub(4) / 8 {
+            return Err(Error::InvalidData(
+                "co64 entry_count indicates more entries than could fit in the box",
+            ));
+        }
         let mut entries = Vec::with_capacity(entry_count as usize);
         for _i in 0..entry_count {
             let chunk_offset = reader.read_u64::<BigEndian>()?;

--- a/src/mp4box/co64.rs
+++ b/src/mp4box/co64.rs
@@ -1,6 +1,7 @@
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 use serde::Serialize;
 use std::io::{Read, Seek, Write};
+use std::mem::size_of;
 
 use crate::mp4box::*;
 
@@ -48,8 +49,10 @@ impl<R: Read + Seek> ReadBox<&mut R> for Co64Box {
 
         let (version, flags) = read_box_header_ext(reader)?;
 
+        let other_size = size_of::<u32>(); // entry_count
+        let entry_size = size_of::<u64>(); // chunk_offset
         let entry_count = reader.read_u32::<BigEndian>()?;
-        if u64::from(entry_count) > size.saturating_sub(4) / 8 {
+        if u64::from(entry_count) > size.saturating_sub(other_size as u64) / entry_size as u64 {
             return Err(Error::InvalidData(
                 "co64 entry_count indicates more entries than could fit in the box",
             ));

--- a/src/mp4box/co64.rs
+++ b/src/mp4box/co64.rs
@@ -49,10 +49,16 @@ impl<R: Read + Seek> ReadBox<&mut R> for Co64Box {
 
         let (version, flags) = read_box_header_ext(reader)?;
 
+        let header_size = HEADER_SIZE + HEADER_EXT_SIZE;
         let other_size = size_of::<u32>(); // entry_count
         let entry_size = size_of::<u64>(); // chunk_offset
         let entry_count = reader.read_u32::<BigEndian>()?;
-        if u64::from(entry_count) > size.saturating_sub(other_size as u64) / entry_size as u64 {
+        if u64::from(entry_count)
+            > size
+                .saturating_sub(header_size)
+                .saturating_sub(other_size as u64)
+                / entry_size as u64
+        {
             return Err(Error::InvalidData(
                 "co64 entry_count indicates more entries than could fit in the box",
             ));

--- a/src/mp4box/ctts.rs
+++ b/src/mp4box/ctts.rs
@@ -55,6 +55,11 @@ impl<R: Read + Seek> ReadBox<&mut R> for CttsBox {
         let (version, flags) = read_box_header_ext(reader)?;
 
         let entry_count = reader.read_u32::<BigEndian>()?;
+        if u64::from(entry_count) > size.saturating_sub(4) / 8 {
+            return Err(Error::InvalidData(
+                "ctts entry_count indicates more entries than could fit in the box",
+            ));
+        }
         let mut entries = Vec::with_capacity(entry_count as usize);
         for _ in 0..entry_count {
             let entry = CttsEntry {

--- a/src/mp4box/dinf.rs
+++ b/src/mp4box/dinf.rs
@@ -49,6 +49,11 @@ impl<R: Read + Seek> ReadBox<&mut R> for DinfBox {
             // Get box header.
             let header = BoxHeader::read(reader)?;
             let BoxHeader { name, size: s } = header;
+            if s > size {
+                return Err(Error::InvalidData(
+                    "dinf box contains a box with a larger size than it",
+                ));
+            }
 
             match name {
                 BoxType::DrefBox => {
@@ -156,6 +161,11 @@ impl<R: Read + Seek> ReadBox<&mut R> for DrefBox {
             // Get box header.
             let header = BoxHeader::read(reader)?;
             let BoxHeader { name, size: s } = header;
+            if s > size {
+                return Err(Error::InvalidData(
+                    "dinf box contains a box with a larger size than it",
+                ));
+            }
 
             match name {
                 BoxType::UrlBox => {

--- a/src/mp4box/dinf.rs
+++ b/src/mp4box/dinf.rs
@@ -254,7 +254,7 @@ impl<R: Read + Seek> ReadBox<&mut R> for UrlBox {
 
         let (version, flags) = read_box_header_ext(reader)?;
 
-        let location = if size - HEADER_SIZE - HEADER_EXT_SIZE > 0 {
+        let location = if size.saturating_sub(HEADER_SIZE + HEADER_EXT_SIZE) > 0 {
             let buf_size = size - HEADER_SIZE - HEADER_EXT_SIZE - 1;
             let mut buf = vec![0u8; buf_size as usize];
             reader.read_exact(&mut buf)?;

--- a/src/mp4box/edts.rs
+++ b/src/mp4box/edts.rs
@@ -54,6 +54,11 @@ impl<R: Read + Seek> ReadBox<&mut R> for EdtsBox {
 
         let header = BoxHeader::read(reader)?;
         let BoxHeader { name, size: s } = header;
+        if s > size {
+            return Err(Error::InvalidData(
+                "edts box contains a box with a larger size than it",
+            ));
+        }
 
         if let BoxType::ElstBox = name {
             let elst = ElstBox::read_box(reader, s)?;

--- a/src/mp4box/elst.rs
+++ b/src/mp4box/elst.rs
@@ -1,6 +1,7 @@
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 use serde::Serialize;
 use std::io::{Read, Seek, Write};
+use std::mem::size_of;
 
 use crate::mp4box::*;
 
@@ -63,9 +64,18 @@ impl<R: Read + Seek> ReadBox<&mut R> for ElstBox {
         let (version, flags) = read_box_header_ext(reader)?;
 
         let entry_count = reader.read_u32::<BigEndian>()?;
-        let header_size = 4;
-        let entry_size = if version == 1 { 20 } else { 12 };
-        if u64::from(entry_count) > size.saturating_sub(header_size) / entry_size {
+        let other_size = size_of::<i32>(); // entry_count
+        let entry_size = {
+            let mut entry_size = 0;
+            entry_size += if version == 1 {
+                size_of::<u64>() + size_of::<i64>() // segment_duration + media_time
+            } else {
+                size_of::<u32>() + size_of::<i32>() // segment_duration + media_time
+            };
+            entry_size += size_of::<i16>() + size_of::<i16>(); // media_rate_integer + media_rate_fraction
+            entry_size
+        };
+        if u64::from(entry_count) > size.saturating_sub(other_size as u64) / entry_size as u64 {
             return Err(Error::InvalidData(
                 "elst entry_count indicates more entries than could fit in the box",
             ));

--- a/src/mp4box/ftyp.rs
+++ b/src/mp4box/ftyp.rs
@@ -53,12 +53,12 @@ impl<R: Read + Seek> ReadBox<&mut R> for FtypBox {
     fn read_box(reader: &mut R, size: u64) -> Result<Self> {
         let start = box_start(reader)?;
 
-        let major = reader.read_u32::<BigEndian>()?;
-        let minor = reader.read_u32::<BigEndian>()?;
-        if size % 4 != 0 {
-            return Err(Error::InvalidData("invalid ftyp size"));
+        if size < 16 || size % 4 != 0 {
+            return Err(Error::InvalidData("ftyp size too small or not aligned"));
         }
         let brand_count = (size - 16) / 4; // header + major + minor
+        let major = reader.read_u32::<BigEndian>()?;
+        let minor = reader.read_u32::<BigEndian>()?;
 
         let mut brands = Vec::new();
         for _ in 0..brand_count {

--- a/src/mp4box/hdlr.rs
+++ b/src/mp4box/hdlr.rs
@@ -52,7 +52,9 @@ impl<R: Read + Seek> ReadBox<&mut R> for HdlrBox {
 
         skip_bytes(reader, 12)?; // reserved
 
-        let buf_size = size - HEADER_SIZE - HEADER_EXT_SIZE - 20 - 1;
+        let buf_size = size
+            .checked_sub(HEADER_SIZE + HEADER_EXT_SIZE + 20 + 1)
+            .ok_or(Error::InvalidData("hdlr size too small"))?;
         let mut buf = vec![0u8; buf_size as usize];
         reader.read_exact(&mut buf)?;
 

--- a/src/mp4box/hev1.rs
+++ b/src/mp4box/hev1.rs
@@ -103,6 +103,11 @@ impl<R: Read + Seek> ReadBox<&mut R> for Hev1Box {
 
         let header = BoxHeader::read(reader)?;
         let BoxHeader { name, size: s } = header;
+        if s > size {
+            return Err(Error::InvalidData(
+                "hev1 box contains a box with a larger size than it",
+            ));
+        }
         if name == BoxType::HvcCBox {
             let hvcc = HvcCBox::read_box(reader, s)?;
 

--- a/src/mp4box/ilst.rs
+++ b/src/mp4box/ilst.rs
@@ -58,6 +58,11 @@ impl<R: Read + Seek> ReadBox<&mut R> for IlstBox {
             // Get box header.
             let header = BoxHeader::read(reader)?;
             let BoxHeader { name, size: s } = header;
+            if s > size {
+                return Err(Error::InvalidData(
+                    "ilst box contains a box with a larger size than it",
+                ));
+            }
 
             match name {
                 BoxType::NameBox => {
@@ -129,6 +134,11 @@ impl<R: Read + Seek> ReadBox<&mut R> for IlstItemBox {
             // Get box header.
             let header = BoxHeader::read(reader)?;
             let BoxHeader { name, size: s } = header;
+            if s > size {
+                return Err(Error::InvalidData(
+                    "ilst item box contains a box with a larger size than it",
+                ));
+            }
 
             match name {
                 BoxType::DataBox => {

--- a/src/mp4box/mdia.rs
+++ b/src/mp4box/mdia.rs
@@ -54,6 +54,11 @@ impl<R: Read + Seek> ReadBox<&mut R> for MdiaBox {
             // Get box header.
             let header = BoxHeader::read(reader)?;
             let BoxHeader { name, size: s } = header;
+            if s > size {
+                return Err(Error::InvalidData(
+                    "mdia box contains a box with a larger size than it",
+                ));
+            }
 
             match name {
                 BoxType::MdhdBox => {

--- a/src/mp4box/minf.rs
+++ b/src/mp4box/minf.rs
@@ -69,6 +69,11 @@ impl<R: Read + Seek> ReadBox<&mut R> for MinfBox {
             // Get box header.
             let header = BoxHeader::read(reader)?;
             let BoxHeader { name, size: s } = header;
+            if s > size {
+                return Err(Error::InvalidData(
+                    "minf box contains a box with a larger size than it",
+                ));
+            }
 
             match name {
                 BoxType::VmhdBox => {

--- a/src/mp4box/moof.rs
+++ b/src/mp4box/moof.rs
@@ -58,6 +58,11 @@ impl<R: Read + Seek> ReadBox<&mut R> for MoofBox {
             // Get box header.
             let header = BoxHeader::read(reader)?;
             let BoxHeader { name, size: s } = header;
+            if s > size {
+                return Err(Error::InvalidData(
+                    "moof box contains a box with a larger size than it",
+                ));
+            }
 
             match name {
                 BoxType::MfhdBox => {

--- a/src/mp4box/moov.rs
+++ b/src/mp4box/moov.rs
@@ -77,6 +77,11 @@ impl<R: Read + Seek> ReadBox<&mut R> for MoovBox {
             // Get box header.
             let header = BoxHeader::read(reader)?;
             let BoxHeader { name, size: s } = header;
+            if s > size {
+                return Err(Error::InvalidData(
+                    "moov box contains a box with a larger size than it",
+                ));
+            }
 
             match name {
                 BoxType::MvhdBox => {

--- a/src/mp4box/mp4a.rs
+++ b/src/mp4box/mp4a.rs
@@ -94,6 +94,11 @@ impl<R: Read + Seek> ReadBox<&mut R> for Mp4aBox {
         if current < start + size {
             let header = BoxHeader::read(reader)?;
             let BoxHeader { name, size: s } = header;
+            if s > size {
+                return Err(Error::InvalidData(
+                    "mp4a box contains a box with a larger size than it",
+                ));
+            }
 
             if name == BoxType::EsdsBox {
                 esds = Some(EsdsBox::read_box(reader, s)?);

--- a/src/mp4box/mvex.rs
+++ b/src/mp4box/mvex.rs
@@ -52,6 +52,11 @@ impl<R: Read + Seek> ReadBox<&mut R> for MvexBox {
             // Get box header.
             let header = BoxHeader::read(reader)?;
             let BoxHeader { name, size: s } = header;
+            if s > size {
+                return Err(Error::InvalidData(
+                    "mvex box contains a box with a larger size than it",
+                ));
+            }
 
             match name {
                 BoxType::MehdBox => {

--- a/src/mp4box/stbl.rs
+++ b/src/mp4box/stbl.rs
@@ -92,6 +92,11 @@ impl<R: Read + Seek> ReadBox<&mut R> for StblBox {
             // Get box header.
             let header = BoxHeader::read(reader)?;
             let BoxHeader { name, size: s } = header;
+            if s > size {
+                return Err(Error::InvalidData(
+                    "stbl box contains a box with a larger size than it",
+                ));
+            }
 
             match name {
                 BoxType::StsdBox => {

--- a/src/mp4box/stco.rs
+++ b/src/mp4box/stco.rs
@@ -1,6 +1,7 @@
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 use serde::Serialize;
 use std::io::{Read, Seek, Write};
+use std::mem::size_of;
 
 use crate::mp4box::*;
 
@@ -48,8 +49,10 @@ impl<R: Read + Seek> ReadBox<&mut R> for StcoBox {
 
         let (version, flags) = read_box_header_ext(reader)?;
 
+        let other_size = size_of::<u32>(); // entry_count
+        let entry_size = size_of::<u32>(); // chunk_offset
         let entry_count = reader.read_u32::<BigEndian>()?;
-        if u64::from(entry_count) > size.saturating_sub(4) / 4 {
+        if u64::from(entry_count) > size.saturating_sub(other_size as u64) / entry_size as u64 {
             return Err(Error::InvalidData(
                 "stco entry_count indicates more entries than could fit in the box",
             ));

--- a/src/mp4box/stco.rs
+++ b/src/mp4box/stco.rs
@@ -49,10 +49,16 @@ impl<R: Read + Seek> ReadBox<&mut R> for StcoBox {
 
         let (version, flags) = read_box_header_ext(reader)?;
 
+        let header_size = HEADER_SIZE + HEADER_EXT_SIZE;
         let other_size = size_of::<u32>(); // entry_count
         let entry_size = size_of::<u32>(); // chunk_offset
         let entry_count = reader.read_u32::<BigEndian>()?;
-        if u64::from(entry_count) > size.saturating_sub(other_size as u64) / entry_size as u64 {
+        if u64::from(entry_count)
+            > size
+                .saturating_sub(header_size)
+                .saturating_sub(other_size as u64)
+                / entry_size as u64
+        {
             return Err(Error::InvalidData(
                 "stco entry_count indicates more entries than could fit in the box",
             ));

--- a/src/mp4box/stco.rs
+++ b/src/mp4box/stco.rs
@@ -49,6 +49,11 @@ impl<R: Read + Seek> ReadBox<&mut R> for StcoBox {
         let (version, flags) = read_box_header_ext(reader)?;
 
         let entry_count = reader.read_u32::<BigEndian>()?;
+        if u64::from(entry_count) > size.saturating_sub(4) / 4 {
+            return Err(Error::InvalidData(
+                "stco entry_count indicates more entries than could fit in the box",
+            ));
+        }
         let mut entries = Vec::with_capacity(entry_count as usize);
         for _i in 0..entry_count {
             let chunk_offset = reader.read_u32::<BigEndian>()?;

--- a/src/mp4box/stsc.rs
+++ b/src/mp4box/stsc.rs
@@ -1,6 +1,7 @@
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 use serde::Serialize;
 use std::io::{Read, Seek, Write};
+use std::mem::size_of;
 
 use crate::mp4box::*;
 
@@ -56,8 +57,10 @@ impl<R: Read + Seek> ReadBox<&mut R> for StscBox {
 
         let (version, flags) = read_box_header_ext(reader)?;
 
+        let other_size = size_of::<u32>(); // entry_count
+        let entry_size = size_of::<u32>() + size_of::<u32>() + size_of::<u32>(); // first_chunk + samples_per_chunk + sample_description_index
         let entry_count = reader.read_u32::<BigEndian>()?;
-        if u64::from(entry_count) > size.saturating_sub(4) / 12 {
+        if u64::from(entry_count) > size.saturating_sub(other_size as u64) / entry_size as u64 {
             return Err(Error::InvalidData(
                 "stsc entry_count indicates more entries than could fit in the box",
             ));

--- a/src/mp4box/stsc.rs
+++ b/src/mp4box/stsc.rs
@@ -57,10 +57,16 @@ impl<R: Read + Seek> ReadBox<&mut R> for StscBox {
 
         let (version, flags) = read_box_header_ext(reader)?;
 
+        let header_size = HEADER_SIZE + HEADER_EXT_SIZE;
         let other_size = size_of::<u32>(); // entry_count
         let entry_size = size_of::<u32>() + size_of::<u32>() + size_of::<u32>(); // first_chunk + samples_per_chunk + sample_description_index
         let entry_count = reader.read_u32::<BigEndian>()?;
-        if u64::from(entry_count) > size.saturating_sub(other_size as u64) / entry_size as u64 {
+        if u64::from(entry_count)
+            > size
+                .saturating_sub(header_size)
+                .saturating_sub(other_size as u64)
+                / entry_size as u64
+        {
             return Err(Error::InvalidData(
                 "stsc entry_count indicates more entries than could fit in the box",
             ));

--- a/src/mp4box/stsd.rs
+++ b/src/mp4box/stsd.rs
@@ -85,6 +85,11 @@ impl<R: Read + Seek> ReadBox<&mut R> for StsdBox {
         // Get box header.
         let header = BoxHeader::read(reader)?;
         let BoxHeader { name, size: s } = header;
+        if s > size {
+            return Err(Error::InvalidData(
+                "stsd box contains a box with a larger size than it",
+            ));
+        }
 
         match name {
             BoxType::Avc1Box => {

--- a/src/mp4box/stss.rs
+++ b/src/mp4box/stss.rs
@@ -1,6 +1,7 @@
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 use serde::Serialize;
 use std::io::{Read, Seek, Write};
+use std::mem::size_of;
 
 use crate::mp4box::*;
 
@@ -48,8 +49,10 @@ impl<R: Read + Seek> ReadBox<&mut R> for StssBox {
 
         let (version, flags) = read_box_header_ext(reader)?;
 
+        let other_size = size_of::<u32>(); // entry_count
+        let entry_size = size_of::<u32>(); // sample_number
         let entry_count = reader.read_u32::<BigEndian>()?;
-        if u64::from(entry_count) > size.saturating_sub(4) / 4 {
+        if u64::from(entry_count) > size.saturating_sub(other_size as u64) / entry_size as u64 {
             return Err(Error::InvalidData(
                 "stss entry_count indicates more entries than could fit in the box",
             ));

--- a/src/mp4box/stss.rs
+++ b/src/mp4box/stss.rs
@@ -49,6 +49,11 @@ impl<R: Read + Seek> ReadBox<&mut R> for StssBox {
         let (version, flags) = read_box_header_ext(reader)?;
 
         let entry_count = reader.read_u32::<BigEndian>()?;
+        if u64::from(entry_count) > size.saturating_sub(4) / 4 {
+            return Err(Error::InvalidData(
+                "stss entry_count indicates more entries than could fit in the box",
+            ));
+        }
         let mut entries = Vec::with_capacity(entry_count as usize);
         for _i in 0..entry_count {
             let sample_number = reader.read_u32::<BigEndian>()?;

--- a/src/mp4box/stss.rs
+++ b/src/mp4box/stss.rs
@@ -49,10 +49,16 @@ impl<R: Read + Seek> ReadBox<&mut R> for StssBox {
 
         let (version, flags) = read_box_header_ext(reader)?;
 
+        let header_size = HEADER_SIZE + HEADER_EXT_SIZE;
         let other_size = size_of::<u32>(); // entry_count
         let entry_size = size_of::<u32>(); // sample_number
         let entry_count = reader.read_u32::<BigEndian>()?;
-        if u64::from(entry_count) > size.saturating_sub(other_size as u64) / entry_size as u64 {
+        if u64::from(entry_count)
+            > size
+                .saturating_sub(header_size)
+                .saturating_sub(other_size as u64)
+                / entry_size as u64
+        {
             return Err(Error::InvalidData(
                 "stss entry_count indicates more entries than could fit in the box",
             ));

--- a/src/mp4box/stts.rs
+++ b/src/mp4box/stts.rs
@@ -1,6 +1,7 @@
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 use serde::Serialize;
 use std::io::{Read, Seek, Write};
+use std::mem::size_of;
 
 use crate::mp4box::*;
 
@@ -54,8 +55,12 @@ impl<R: Read + Seek> ReadBox<&mut R> for SttsBox {
 
         let (version, flags) = read_box_header_ext(reader)?;
 
+        let other_size = size_of::<u32>(); // entry_count
+        let entry_size = size_of::<u32>() + size_of::<u32>(); // sample_count + sample_delta
         let entry_count = reader.read_u32::<BigEndian>()?;
-        if u64::from(entry_count) > size.saturating_sub(4) / 8 {
+        if u64::from(entry_count)
+            > size.saturating_sub(other_size as u64) / entry_size as u64
+        {
             return Err(Error::InvalidData(
                 "stts entry_count indicates more entries than could fit in the box",
             ));

--- a/src/mp4box/stts.rs
+++ b/src/mp4box/stts.rs
@@ -55,11 +55,15 @@ impl<R: Read + Seek> ReadBox<&mut R> for SttsBox {
 
         let (version, flags) = read_box_header_ext(reader)?;
 
+        let header_size = HEADER_SIZE + HEADER_EXT_SIZE;
         let other_size = size_of::<u32>(); // entry_count
         let entry_size = size_of::<u32>() + size_of::<u32>(); // sample_count + sample_delta
         let entry_count = reader.read_u32::<BigEndian>()?;
         if u64::from(entry_count)
-            > size.saturating_sub(other_size as u64) / entry_size as u64
+            > size
+                .saturating_sub(header_size)
+                .saturating_sub(other_size as u64)
+                / entry_size as u64
         {
             return Err(Error::InvalidData(
                 "stts entry_count indicates more entries than could fit in the box",

--- a/src/mp4box/stts.rs
+++ b/src/mp4box/stts.rs
@@ -55,6 +55,11 @@ impl<R: Read + Seek> ReadBox<&mut R> for SttsBox {
         let (version, flags) = read_box_header_ext(reader)?;
 
         let entry_count = reader.read_u32::<BigEndian>()?;
+        if u64::from(entry_count) > size.saturating_sub(4) / 8 {
+            return Err(Error::InvalidData(
+                "stts entry_count indicates more entries than could fit in the box",
+            ));
+        }
         let mut entries = Vec::with_capacity(entry_count as usize);
         for _i in 0..entry_count {
             let entry = SttsEntry {

--- a/src/mp4box/traf.rs
+++ b/src/mp4box/traf.rs
@@ -59,6 +59,11 @@ impl<R: Read + Seek> ReadBox<&mut R> for TrafBox {
             // Get box header.
             let header = BoxHeader::read(reader)?;
             let BoxHeader { name, size: s } = header;
+            if s > size {
+                return Err(Error::InvalidData(
+                    "traf box contains a box with a larger size than it",
+                ));
+            }
 
             match name {
                 BoxType::TfhdBox => {

--- a/src/mp4box/trak.rs
+++ b/src/mp4box/trak.rs
@@ -68,6 +68,11 @@ impl<R: Read + Seek> ReadBox<&mut R> for TrakBox {
             // Get box header.
             let header = BoxHeader::read(reader)?;
             let BoxHeader { name, size: s } = header;
+            if s > size {
+                return Err(Error::InvalidData(
+                    "trak box contains a box with a larger size than it",
+                ));
+            }
 
             match name {
                 BoxType::TkhdBox => {

--- a/src/mp4box/trun.rs
+++ b/src/mp4box/trun.rs
@@ -1,6 +1,7 @@
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 use serde::Serialize;
 use std::io::{Read, Seek, Write};
+use std::mem::size_of;
 
 use crate::mp4box::*;
 
@@ -83,6 +84,14 @@ impl<R: Read + Seek> ReadBox<&mut R> for TrunBox {
 
         let (version, flags) = read_box_header_ext(reader)?;
 
+        let other_size = size_of::<u32>() // sample_count
+            + if TrunBox::FLAG_DATA_OFFSET & flags > 0 { size_of::<i32>() } else { 0 } // data_offset
+            + if TrunBox::FLAG_FIRST_SAMPLE_FLAGS & flags > 0 { size_of::<u32>() } else { 0 }; // first_sample_flags
+        let sample_size = if TrunBox::FLAG_SAMPLE_DURATION & flags > 0 { size_of::<u32>() } else { 0 } // sample_duration
+            + if TrunBox::FLAG_SAMPLE_SIZE & flags > 0 { size_of::<u32>() } else { 0 } // sample_size
+            + if TrunBox::FLAG_SAMPLE_FLAGS & flags > 0 { size_of::<u32>() } else { 0 } // sample_flags
+            + if TrunBox::FLAG_SAMPLE_CTS & flags > 0 { size_of::<u32>() } else { 0 }; // sample_composition_time_offset
+
         let sample_count = reader.read_u32::<BigEndian>()?;
 
         let data_offset = if TrunBox::FLAG_DATA_OFFSET & flags > 0 {
@@ -101,10 +110,8 @@ impl<R: Read + Seek> ReadBox<&mut R> for TrunBox {
         let mut sample_sizes = Vec::new();
         let mut sample_flags = Vec::new();
         let mut sample_cts = Vec::new();
-        let header_size = ((0x0000ff & flags).count_ones() + 1) * 4;
-        let entry_size = (0x00ff00 & flags).count_ones() * 4;
-        if u64::from(sample_count) * u64::from(entry_size)
-            > size.saturating_sub(u64::from(header_size))
+        if u64::from(sample_count) * sample_size as u64
+            > size.saturating_sub(other_size as u64)
         {
             return Err(Error::InvalidData(
                 "trun sample_count indicates more values than could fit in the box",
@@ -122,6 +129,7 @@ impl<R: Read + Seek> ReadBox<&mut R> for TrunBox {
         if TrunBox::FLAG_SAMPLE_CTS & flags > 0 {
             sample_cts.reserve(sample_count as usize);
         }
+
         for _ in 0..sample_count {
             if TrunBox::FLAG_SAMPLE_DURATION & flags > 0 {
                 let duration = reader.read_u32::<BigEndian>()?;

--- a/src/mp4box/udta.rs
+++ b/src/mp4box/udta.rs
@@ -55,6 +55,11 @@ impl<R: Read + Seek> ReadBox<&mut R> for UdtaBox {
             // Get box header.
             let header = BoxHeader::read(reader)?;
             let BoxHeader { name, size: s } = header;
+            if s > size {
+                return Err(Error::InvalidData(
+                    "udta box contains a box with a larger size than it",
+                ));
+            }
 
             match name {
                 BoxType::MetaBox => {

--- a/src/mp4box/vp09.rs
+++ b/src/mp4box/vp09.rs
@@ -121,6 +121,11 @@ impl<R: Read + Seek> ReadBox<&mut R> for Vp09Box {
 
         let vpcc = {
             let header = BoxHeader::read(reader)?;
+            if header.size > size {
+                return Err(Error::InvalidData(
+                    "vp09 box contains a box with a larger size than it",
+                ));
+            }
             VpccBox::read_box(reader, header.size)?
         };
 

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -31,6 +31,11 @@ impl<R: Read + Seek> Mp4Reader<R> {
             // Get box header.
             let header = BoxHeader::read(&mut reader)?;
             let BoxHeader { name, size: s } = header;
+            if s > size {
+                return Err(Error::InvalidData(
+                    "file contains a box with a larger size than it",
+                ));
+            }
 
             // Break if size zero BoxHeader, which can result in dead-loop.
             if s == 0 {

--- a/src/track.rs
+++ b/src/track.rs
@@ -234,7 +234,9 @@ impl Mp4Track {
             let mut sample_count = 0u32;
             for traf in self.trafs.iter() {
                 if let Some(ref trun) = traf.trun {
-                    sample_count += trun.sample_count;
+                    sample_count = sample_count
+                        .checked_add(trun.sample_count)
+                        .expect("attempt to sum trun sample_count with overflow");
                 }
             }
             sample_count
@@ -342,12 +344,18 @@ impl Mp4Track {
 
     fn ctts_index(&self, sample_id: u32) -> Result<(usize, u32)> {
         let ctts = self.trak.mdia.minf.stbl.ctts.as_ref().unwrap();
-        let mut sample_count = 1;
+        let mut sample_count: u32 = 1;
         for (i, entry) in ctts.entries.iter().enumerate() {
-            if sample_id < sample_count + entry.sample_count {
+            let next_sample_count =
+                sample_count
+                    .checked_add(entry.sample_count)
+                    .ok_or(Error::InvalidData(
+                        "attempt to sum ctts entries sample_count with overflow",
+                    ))?;
+            if sample_id < next_sample_count {
                 return Ok((i, sample_count));
             }
-            sample_count += entry.sample_count;
+            sample_count = next_sample_count;
         }
 
         Err(Error::EntryInStblNotFound(
@@ -367,7 +375,9 @@ impl Mp4Track {
                 if sample_count > (global_idx - offset) {
                     return Some((traf_idx, (global_idx - offset) as _));
                 }
-                offset += sample_count;
+                offset = offset
+                    .checked_add(sample_count)
+                    .expect("attempt to sum trun sample_count with overflow");
             }
         }
         None
@@ -441,7 +451,13 @@ impl Mp4Track {
             let first_sample = stsc_entry.first_sample;
             let samples_per_chunk = stsc_entry.samples_per_chunk;
 
-            let chunk_id = first_chunk + (sample_id - first_sample) / samples_per_chunk;
+            let chunk_id = sample_id
+                .checked_sub(first_sample)
+                .and_then(|n| n.checked_add(first_chunk))
+                .map(|n| n / samples_per_chunk)
+                .ok_or(Error::InvalidData(
+                    "attempt to calculate stsc chunk_id with overflow",
+                ))?;
 
             let chunk_offset = self.chunk_offset(chunk_id)?;
 
@@ -459,7 +475,7 @@ impl Mp4Track {
     fn sample_time(&self, sample_id: u32) -> Result<(u64, u32)> {
         let stts = &self.trak.mdia.minf.stbl.stts;
 
-        let mut sample_count = 1;
+        let mut sample_count: u32 = 1;
         let mut elapsed = 0;
 
         if !self.trafs.is_empty() {
@@ -467,13 +483,19 @@ impl Mp4Track {
             Ok((start_time, self.default_sample_duration))
         } else {
             for entry in stts.entries.iter() {
-                if sample_id < sample_count + entry.sample_count {
+                let new_sample_count =
+                    sample_count
+                        .checked_add(entry.sample_count)
+                        .ok_or(Error::InvalidData(
+                            "attempt to sum stts entries sample_count with overflow",
+                        ))?;
+                if sample_id < new_sample_count {
                     let start_time =
                         (sample_id - sample_count) as u64 * entry.sample_delta as u64 + elapsed;
                     return Ok((start_time, entry.sample_delta));
                 }
 
-                sample_count += entry.sample_count;
+                sample_count = new_sample_count;
                 elapsed += entry.sample_count as u64 * entry.sample_delta as u64;
             }
 

--- a/src/track.rs
+++ b/src/track.rs
@@ -453,8 +453,8 @@ impl Mp4Track {
 
             let chunk_id = sample_id
                 .checked_sub(first_sample)
-                .and_then(|n| n.checked_add(first_chunk))
                 .map(|n| n / samples_per_chunk)
+                .and_then(|n| n.checked_add(first_chunk))
                 .ok_or(Error::InvalidData(
                     "attempt to calculate stsc chunk_id with overflow",
                 ))?;

--- a/src/track.rs
+++ b/src/track.rs
@@ -540,7 +540,11 @@ impl Mp4Track {
             Err(Error::EntryInStblNotFound(_, _, _)) => return Ok(None),
             Err(err) => return Err(err),
         };
-        let sample_size = self.sample_size(sample_id).unwrap();
+        let sample_size = match self.sample_size(sample_id) {
+            Ok(size) => size,
+            Err(Error::EntryInStblNotFound(_, _, _)) => return Ok(None),
+            Err(err) => return Err(err),
+        };
 
         let mut buffer = vec![0x0u8; sample_size as usize];
         reader.seek(SeekFrom::Start(sample_offset))?;


### PR DESCRIPTION
Add checked arithmetic in several places where the code:
* Reads a length from an open file, and tries to allocate that much memory
* Subtracts from a length, overflows if it's unexpectedly small, and tries to allocate that much memory
* Performs unchecked arithmetic on a value (e.g. to compute a sample_id), and panics (in debug mode)

(da83d3c isn't an overflow per se, but I think it's in the same spirit.)