### PR TITLE
Fix link to examples in docs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,7 +62,7 @@
 //! ```
 //!
 //! [mp4box]: https://github.com/alfg/mp4-rust/blob/master/src/mp4box/mod.rs
-//! [examples]: https://github.com/alfg/mp4-rust/blob/master/src/examples
+//! [examples]: https://github.com/alfg/mp4-rust/tree/master/examples
 #![doc(html_root_url = "https://docs.rs/mp4/*")]
 
 use std::fs::File;


### PR DESCRIPTION
The link was outdated.