### PR TITLE
Add support for multiple trex boxes.

### DIFF
--- a/examples/mp4dump.rs
+++ b/examples/mp4dump.rs
@@ -56,7 +56,9 @@ fn get_boxes(file: File) -> Result<Vec<Box>> {
         if let Some(mehd) = &mvex.mehd {
             boxes.push(build_box(mehd));
         }
-        boxes.push(build_box(&mvex.trex));
+        for trex in mvex.trexs.iter() {
+            boxes.push(build_box(trex));
+        }
     }
 
     // trak.


### PR DESCRIPTION
While it's common to construct a fMP4 file for a single track, it's totally valid to have multiple tracks. This means you also need multiple to support multiple trex boxes.

Untested.