### PR TITLE
remove some calls to  unwrap

### DIFF
--- a/src/mp4box/avc1.rs
+++ b/src/mp4box/avc1.rs
@@ -68,7 +68,7 @@ impl Mp4Box for Avc1Box {
     }
 
     fn to_json(&self) -> Result<String> {
-        Ok(serde_json::to_string(&self).unwrap())
+        serde_json::to_string(&self).map_err(|e| crate::error::Error::IoError(e.into()))
     }
 
     fn summary(&self) -> Result<String> {
@@ -200,7 +200,7 @@ impl Mp4Box for AvcCBox {
     }
 
     fn to_json(&self) -> Result<String> {
-        Ok(serde_json::to_string(&self).unwrap())
+        serde_json::to_string(&self).map_err(|e| crate::error::Error::IoError(e.into()))
     }
 
     fn summary(&self) -> Result<String> {

--- a/src/mp4box/co64.rs
+++ b/src/mp4box/co64.rs
@@ -34,7 +34,7 @@ impl Mp4Box for Co64Box {
     }
 
     fn to_json(&self) -> Result<String> {
-        Ok(serde_json::to_string(&self).unwrap())
+        serde_json::to_string(&self).map_err(|e| crate::error::Error::IoError(e.into()))
     }
 
     fn summary(&self) -> Result<String> {

--- a/src/mp4box/ctts.rs
+++ b/src/mp4box/ctts.rs
@@ -40,7 +40,7 @@ impl Mp4Box for CttsBox {
     }
 
     fn to_json(&self) -> Result<String> {
-        Ok(serde_json::to_string(&self).unwrap())
+        serde_json::to_string(&self).map_err(|e| crate::error::Error::IoError(e.into()))
     }
 
     fn summary(&self) -> Result<String> {

--- a/src/mp4box/data.rs
+++ b/src/mp4box/data.rs
@@ -37,7 +37,7 @@ impl Mp4Box for DataBox {
     }
 
     fn to_json(&self) -> Result<String> {
-        Ok(serde_json::to_string(&self).unwrap())
+        serde_json::to_string(&self).map_err(|e| crate::error::Error::IoError(e.into()))
     }
 
     fn summary(&self) -> Result<String> {

--- a/src/mp4box/dinf.rs
+++ b/src/mp4box/dinf.rs
@@ -28,7 +28,7 @@ impl Mp4Box for DinfBox {
     }
 
     fn to_json(&self) -> Result<String> {
-        Ok(serde_json::to_string(&self).unwrap())
+        serde_json::to_string(&self).map_err(|e| crate::error::Error::IoError(e.into()))
     }
 
     fn summary(&self) -> Result<String> {
@@ -132,7 +132,7 @@ impl Mp4Box for DrefBox {
     }
 
     fn to_json(&self) -> Result<String> {
-        Ok(serde_json::to_string(&self).unwrap())
+        serde_json::to_string(&self).map_err(|e| crate::error::Error::IoError(e.into()))
     }
 
     fn summary(&self) -> Result<String> {
@@ -249,7 +249,7 @@ impl Mp4Box for UrlBox {
     }
 
     fn to_json(&self) -> Result<String> {
-        Ok(serde_json::to_string(&self).unwrap())
+        serde_json::to_string(&self).map_err(|e| crate::error::Error::IoError(e.into()))
     }
 
     fn summary(&self) -> Result<String> {

--- a/src/mp4box/edts.rs
+++ b/src/mp4box/edts.rs
@@ -37,7 +37,7 @@ impl Mp4Box for EdtsBox {
     }
 
     fn to_json(&self) -> Result<String> {
-        Ok(serde_json::to_string(&self).unwrap())
+        serde_json::to_string(&self).map_err(|e| crate::error::Error::IoError(e.into()))
     }
 
     fn summary(&self) -> Result<String> {

--- a/src/mp4box/elst.rs
+++ b/src/mp4box/elst.rs
@@ -48,7 +48,7 @@ impl Mp4Box for ElstBox {
     }
 
     fn to_json(&self) -> Result<String> {
-        Ok(serde_json::to_string(&self).unwrap())
+        serde_json::to_string(&self).map_err(|e| crate::error::Error::IoError(e.into()))
     }
 
     fn summary(&self) -> Result<String> {

--- a/src/mp4box/emsg.rs
+++ b/src/mp4box/emsg.rs
@@ -49,7 +49,7 @@ impl Mp4Box for EmsgBox {
     }
 
     fn to_json(&self) -> Result<String> {
-        Ok(serde_json::to_string(&self).unwrap())
+        serde_json::to_string(&self).map_err(|e| crate::error::Error::IoError(e.into()))
     }
 
     fn summary(&self) -> Result<String> {

--- a/src/mp4box/ftyp.rs
+++ b/src/mp4box/ftyp.rs
@@ -31,7 +31,7 @@ impl Mp4Box for FtypBox {
     }
 
     fn to_json(&self) -> Result<String> {
-        Ok(serde_json::to_string(&self).unwrap())
+        serde_json::to_string(&self).map_err(|e| crate::error::Error::IoError(e.into()))
     }
 
     fn summary(&self) -> Result<String> {

--- a/src/mp4box/hdlr.rs
+++ b/src/mp4box/hdlr.rs
@@ -32,7 +32,7 @@ impl Mp4Box for HdlrBox {
     }
 
     fn to_json(&self) -> Result<String> {
-        Ok(serde_json::to_string(&self).unwrap())
+        serde_json::to_string(&self).map_err(|e| crate::error::Error::IoError(e.into()))
     }
 
     fn summary(&self) -> Result<String> {

--- a/src/mp4box/hev1.rs
+++ b/src/mp4box/hev1.rs
@@ -68,7 +68,7 @@ impl Mp4Box for Hev1Box {
     }
 
     fn to_json(&self) -> Result<String> {
-        Ok(serde_json::to_string(&self).unwrap())
+        serde_json::to_string(&self).map_err(|e| crate::error::Error::IoError(e.into()))
     }
 
     fn summary(&self) -> Result<String> {
@@ -181,7 +181,7 @@ impl Mp4Box for HvcCBox {
     }
 
     fn to_json(&self) -> Result<String> {
-        Ok(serde_json::to_string(&self).unwrap())
+        serde_json::to_string(&self).map_err(|e| crate::error::Error::IoError(e.into()))
     }
 
     fn summary(&self) -> Result<String> {

--- a/src/mp4box/ilst.rs
+++ b/src/mp4box/ilst.rs
@@ -37,7 +37,7 @@ impl Mp4Box for IlstBox {
     }
 
     fn to_json(&self) -> Result<String> {
-        Ok(serde_json::to_string(&self).unwrap())
+        serde_json::to_string(&self).map_err(|e| crate::error::Error::IoError(e.into()))
     }
 
     fn summary(&self) -> Result<String> {

--- a/src/mp4box/mdhd.rs
+++ b/src/mp4box/mdhd.rs
@@ -58,7 +58,7 @@ impl Mp4Box for MdhdBox {
     }
 
     fn to_json(&self) -> Result<String> {
-        Ok(serde_json::to_string(&self).unwrap())
+        serde_json::to_string(&self).map_err(|e| crate::error::Error::IoError(e.into()))
     }
 
     fn summary(&self) -> Result<String> {

--- a/src/mp4box/mdia.rs
+++ b/src/mp4box/mdia.rs
@@ -31,7 +31,7 @@ impl Mp4Box for MdiaBox {
     }
 
     fn to_json(&self) -> Result<String> {
-        Ok(serde_json::to_string(&self).unwrap())
+        serde_json::to_string(&self).map_err(|e| crate::error::Error::IoError(e.into()))
     }
 
     fn summary(&self) -> Result<String> {

--- a/src/mp4box/mehd.rs
+++ b/src/mp4box/mehd.rs
@@ -38,7 +38,7 @@ impl Mp4Box for MehdBox {
     }
 
     fn to_json(&self) -> Result<String> {
-        Ok(serde_json::to_string(&self).unwrap())
+        serde_json::to_string(&self).map_err(|e| crate::error::Error::IoError(e.into()))
     }
 
     fn summary(&self) -> Result<String> {

--- a/src/mp4box/meta.rs
+++ b/src/mp4box/meta.rs
@@ -57,7 +57,7 @@ impl Mp4Box for MetaBox {
     }
 
     fn to_json(&self) -> Result<String> {
-        Ok(serde_json::to_string(&self).unwrap())
+        serde_json::to_string(&self).map_err(|e| crate::error::Error::IoError(e.into()))
     }
 
     fn summary(&self) -> Result<String> {

--- a/src/mp4box/mfhd.rs
+++ b/src/mp4box/mfhd.rs
@@ -41,7 +41,7 @@ impl Mp4Box for MfhdBox {
     }
 
     fn to_json(&self) -> Result<String> {
-        Ok(serde_json::to_string(&self).unwrap())
+        serde_json::to_string(&self).map_err(|e| crate::error::Error::IoError(e.into()))
     }
 
     fn summary(&self) -> Result<String> {

--- a/src/mp4box/minf.rs
+++ b/src/mp4box/minf.rs
@@ -45,7 +45,7 @@ impl Mp4Box for MinfBox {
     }
 
     fn to_json(&self) -> Result<String> {
-        Ok(serde_json::to_string(&self).unwrap())
+        serde_json::to_string(&self).map_err(|e| crate::error::Error::IoError(e.into()))
     }
 
     fn summary(&self) -> Result<String> {

--- a/src/mp4box/mod.rs
+++ b/src/mp4box/mod.rs
@@ -86,6 +86,7 @@ pub(crate) mod mp4a;
 pub(crate) mod mvex;
 pub(crate) mod mvhd;
 pub(crate) mod smhd;
+pub(crate) mod soun;
 pub(crate) mod stbl;
 pub(crate) mod stco;
 pub(crate) mod stsc;
@@ -198,7 +199,8 @@ boxtype! {
     DayBox => 0xa9646179,
     CovrBox => 0x636f7672,
     DescBox => 0x64657363,
-    WideBox => 0x77696465
+    WideBox => 0x77696465,
+    SounBox => 0x736F756E
 }
 
 pub trait Mp4Box: Sized {

--- a/src/mp4box/moof.rs
+++ b/src/mp4box/moof.rs
@@ -36,7 +36,7 @@ impl Mp4Box for MoofBox {
     }
 
     fn to_json(&self) -> Result<String> {
-        Ok(serde_json::to_string(&self).unwrap())
+        serde_json::to_string(&self).map_err(|e| crate::error::Error::IoError(e.into()))
     }
 
     fn summary(&self) -> Result<String> {

--- a/src/mp4box/moov.rs
+++ b/src/mp4box/moov.rs
@@ -52,7 +52,7 @@ impl Mp4Box for MoovBox {
     }
 
     fn to_json(&self) -> Result<String> {
-        Ok(serde_json::to_string(&self).unwrap())
+        serde_json::to_string(&self).map_err(|e| crate::error::Error::IoError(e.into()))
     }
 
     fn summary(&self) -> Result<String> {

--- a/src/mp4box/mp4a.rs
+++ b/src/mp4box/mp4a.rs
@@ -61,7 +61,7 @@ impl Mp4Box for Mp4aBox {
     }
 
     fn to_json(&self) -> Result<String> {
-        Ok(serde_json::to_string(&self).unwrap())
+        serde_json::to_string(&self).map_err(|e| crate::error::Error::IoError(e.into()))
     }
 
     fn summary(&self) -> Result<String> {
@@ -170,7 +170,7 @@ impl Mp4Box for EsdsBox {
     }
 
     fn to_json(&self) -> Result<String> {
-        Ok(serde_json::to_string(&self).unwrap())
+        serde_json::to_string(&self).map_err(|e| crate::error::Error::IoError(e.into()))
     }
 
     fn summary(&self) -> Result<String> {

--- a/src/mp4box/mvex.rs
+++ b/src/mp4box/mvex.rs
@@ -30,7 +30,7 @@ impl Mp4Box for MvexBox {
     }
 
     fn to_json(&self) -> Result<String> {
-        Ok(serde_json::to_string(&self).unwrap())
+        serde_json::to_string(&self).map_err(|e| crate::error::Error::IoError(e.into()))
     }
 
     fn summary(&self) -> Result<String> {

--- a/src/mp4box/mvhd.rs
+++ b/src/mp4box/mvhd.rs
@@ -67,7 +67,7 @@ impl Mp4Box for MvhdBox {
     }
 
     fn to_json(&self) -> Result<String> {
-        Ok(serde_json::to_string(&self).unwrap())
+        serde_json::to_string(&self).map_err(|e| crate::error::Error::IoError(e.into()))
     }
 
     fn summary(&self) -> Result<String> {

--- a/src/mp4box/smhd.rs
+++ b/src/mp4box/smhd.rs
@@ -43,7 +43,7 @@ impl Mp4Box for SmhdBox {
     }
 
     fn to_json(&self) -> Result<String> {
-        Ok(serde_json::to_string(&self).unwrap())
+        serde_json::to_string(&self).map_err(|e| crate::error::Error::IoError(e.into()))
     }
 
     fn summary(&self) -> Result<String> {

--- a/src/mp4box/soun.rs
+++ b/src/mp4box/soun.rs
@@ -1,0 +1,32 @@
+use serde::Serialize;
+
+use crate::mp4box::*;
+
+// for opus
+// https://opus-codec.org/docs/opus_in_isobmff.html
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct SounBox {}
+
+impl Default for SounBox {
+    fn default() -> Self {
+        Self {}
+    }
+}
+
+impl Mp4Box for SounBox {
+    fn box_type(&self) -> BoxType {
+        BoxType::SounBox
+    }
+
+    fn box_size(&self) -> u64 {
+        todo!()
+    }
+
+    fn to_json(&self) -> Result<String> {
+        serde_json::to_string(&self).map_err(|e| crate::error::Error::IoError(e.into()))
+    }
+
+    fn summary(&self) -> Result<String> {
+        todo!()
+    }
+}

--- a/src/mp4box/stbl.rs
+++ b/src/mp4box/stbl.rs
@@ -64,7 +64,7 @@ impl Mp4Box for StblBox {
     }
 
     fn to_json(&self) -> Result<String> {
-        Ok(serde_json::to_string(&self).unwrap())
+        serde_json::to_string(&self).map_err(|e| crate::error::Error::IoError(e.into()))
     }
 
     fn summary(&self) -> Result<String> {

--- a/src/mp4box/stco.rs
+++ b/src/mp4box/stco.rs
@@ -34,7 +34,7 @@ impl Mp4Box for StcoBox {
     }
 
     fn to_json(&self) -> Result<String> {
-        Ok(serde_json::to_string(&self).unwrap())
+        serde_json::to_string(&self).map_err(|e| crate::error::Error::IoError(e.into()))
     }
 
     fn summary(&self) -> Result<String> {

--- a/src/mp4box/stsc.rs
+++ b/src/mp4box/stsc.rs
@@ -42,7 +42,7 @@ impl Mp4Box for StscBox {
     }
 
     fn to_json(&self) -> Result<String> {
-        Ok(serde_json::to_string(&self).unwrap())
+        serde_json::to_string(&self).map_err(|e| crate::error::Error::IoError(e.into()))
     }
 
     fn summary(&self) -> Result<String> {

--- a/src/mp4box/stsd.rs
+++ b/src/mp4box/stsd.rs
@@ -59,7 +59,7 @@ impl Mp4Box for StsdBox {
     }
 
     fn to_json(&self) -> Result<String> {
-        Ok(serde_json::to_string(&self).unwrap())
+        serde_json::to_string(&self).map_err(|e| crate::error::Error::IoError(e.into()))
     }
 
     fn summary(&self) -> Result<String> {

--- a/src/mp4box/stss.rs
+++ b/src/mp4box/stss.rs
@@ -34,7 +34,7 @@ impl Mp4Box for StssBox {
     }
 
     fn to_json(&self) -> Result<String> {
-        Ok(serde_json::to_string(&self).unwrap())
+        serde_json::to_string(&self).map_err(|e| crate::error::Error::IoError(e.into()))
     }
 
     fn summary(&self) -> Result<String> {

--- a/src/mp4box/stsz.rs
+++ b/src/mp4box/stsz.rs
@@ -36,7 +36,7 @@ impl Mp4Box for StszBox {
     }
 
     fn to_json(&self) -> Result<String> {
-        Ok(serde_json::to_string(&self).unwrap())
+        serde_json::to_string(&self).map_err(|e| crate::error::Error::IoError(e.into()))
     }
 
     fn summary(&self) -> Result<String> {

--- a/src/mp4box/stts.rs
+++ b/src/mp4box/stts.rs
@@ -40,7 +40,7 @@ impl Mp4Box for SttsBox {
     }
 
     fn to_json(&self) -> Result<String> {
-        Ok(serde_json::to_string(&self).unwrap())
+        serde_json::to_string(&self).map_err(|e| crate::error::Error::IoError(e.into()))
     }
 
     fn summary(&self) -> Result<String> {

--- a/src/mp4box/tfdt.rs
+++ b/src/mp4box/tfdt.rs
@@ -37,7 +37,7 @@ impl Mp4Box for TfdtBox {
     }
 
     fn to_json(&self) -> Result<String> {
-        Ok(serde_json::to_string(&self).unwrap())
+        serde_json::to_string(&self).map_err(|e| crate::error::Error::IoError(e.into()))
     }
 
     fn summary(&self) -> Result<String> {

--- a/src/mp4box/tfhd.rs
+++ b/src/mp4box/tfhd.rs
@@ -58,7 +58,7 @@ impl Mp4Box for TfhdBox {
     }
 
     fn to_json(&self) -> Result<String> {
-        Ok(serde_json::to_string(&self).unwrap())
+        serde_json::to_string(&self).map_err(|e| crate::error::Error::IoError(e.into()))
     }
 
     fn summary(&self) -> Result<String> {

--- a/src/mp4box/tkhd.rs
+++ b/src/mp4box/tkhd.rs
@@ -126,7 +126,7 @@ impl Mp4Box for TkhdBox {
     }
 
     fn to_json(&self) -> Result<String> {
-        Ok(serde_json::to_string(&self).unwrap())
+        serde_json::to_string(&self).map_err(|e| crate::error::Error::IoError(e.into()))
     }
 
     fn summary(&self) -> Result<String> {

--- a/src/mp4box/traf.rs
+++ b/src/mp4box/traf.rs
@@ -36,7 +36,7 @@ impl Mp4Box for TrafBox {
     }
 
     fn to_json(&self) -> Result<String> {
-        Ok(serde_json::to_string(&self).unwrap())
+        serde_json::to_string(&self).map_err(|e| crate::error::Error::IoError(e.into()))
     }
 
     fn summary(&self) -> Result<String> {

--- a/src/mp4box/trak.rs
+++ b/src/mp4box/trak.rs
@@ -44,7 +44,7 @@ impl Mp4Box for TrakBox {
     }
 
     fn to_json(&self) -> Result<String> {
-        Ok(serde_json::to_string(&self).unwrap())
+        serde_json::to_string(&self).map_err(|e| crate::error::Error::IoError(e.into()))
     }
 
     fn summary(&self) -> Result<String> {

--- a/src/mp4box/trex.rs
+++ b/src/mp4box/trex.rs
@@ -35,7 +35,7 @@ impl Mp4Box for TrexBox {
     }
 
     fn to_json(&self) -> Result<String> {
-        Ok(serde_json::to_string(&self).unwrap())
+        serde_json::to_string(&self).map_err(|e| crate::error::Error::IoError(e.into()))
     }
 
     fn summary(&self) -> Result<String> {

--- a/src/mp4box/trun.rs
+++ b/src/mp4box/trun.rs
@@ -69,7 +69,7 @@ impl Mp4Box for TrunBox {
     }
 
     fn to_json(&self) -> Result<String> {
-        Ok(serde_json::to_string(&self).unwrap())
+        serde_json::to_string(&self).map_err(|e| crate::error::Error::IoError(e.into()))
     }
 
     fn summary(&self) -> Result<String> {

--- a/src/mp4box/tx3g.rs
+++ b/src/mp4box/tx3g.rs
@@ -62,7 +62,7 @@ impl Mp4Box for Tx3gBox {
     }
 
     fn to_json(&self) -> Result<String> {
-        Ok(serde_json::to_string(&self).unwrap())
+        serde_json::to_string(&self).map_err(|e| crate::error::Error::IoError(e.into()))
     }
 
     fn summary(&self) -> Result<String> {

--- a/src/mp4box/udta.rs
+++ b/src/mp4box/udta.rs
@@ -35,7 +35,7 @@ impl Mp4Box for UdtaBox {
     }
 
     fn to_json(&self) -> Result<String> {
-        Ok(serde_json::to_string(&self).unwrap())
+        serde_json::to_string(&self).map_err(|e| crate::error::Error::IoError(e.into()))
     }
 
     fn summary(&self) -> Result<String> {

--- a/src/mp4box/vmhd.rs
+++ b/src/mp4box/vmhd.rs
@@ -39,7 +39,7 @@ impl Mp4Box for VmhdBox {
     }
 
     fn to_json(&self) -> Result<String> {
-        Ok(serde_json::to_string(&self).unwrap())
+        serde_json::to_string(&self).map_err(|e| crate::error::Error::IoError(e.into()))
     }
 
     fn summary(&self) -> Result<String> {

--- a/src/mp4box/vp09.rs
+++ b/src/mp4box/vp09.rs
@@ -75,7 +75,7 @@ impl Mp4Box for Vp09Box {
     }
 
     fn to_json(&self) -> Result<String> {
-        Ok(serde_json::to_string(&self).unwrap())
+        serde_json::to_string(&self).map_err(|e| crate::error::Error::IoError(e.into()))
     }
 
     fn summary(&self) -> Result<String> {

--- a/src/mp4box/vpcc.rs
+++ b/src/mp4box/vpcc.rs
@@ -32,7 +32,7 @@ impl Mp4Box for VpccBox {
     }
 
     fn to_json(&self) -> Result<String> {
-        Ok(serde_json::to_string(&self).unwrap())
+        serde_json::to_string(&self).map_err(|e| crate::error::Error::IoError(e.into()))
     }
 
     fn summary(&self) -> Result<String> {

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -116,8 +116,8 @@ impl<R: Read + Seek> Mp4Reader<R> {
 
         Ok(Mp4Reader {
             reader,
-            ftyp: ftyp.unwrap(),
-            moov: moov.unwrap(),
+            ftyp: ftyp.ok_or(crate::error::Error::BoxNotFound(BoxType::FtypBox))?,
+            moov: moov.ok_or(crate::error::Error::BoxNotFound(BoxType::MoovBox))?,
             moofs,
             emsgs,
             size,


### PR DESCRIPTION
I was adding Opus support to this library when I found this 
![Screenshot from 2023-07-05 10-01-53](https://github.com/alfg/mp4-rust/assets/8636602/63dc40a8-a964-4ea9-9e2f-fd95bbe6982a)

I don't want to use this library anymore but I figured I'd offer the fixes I made along the way. you can delete the `SounBox` module if you want. 
