### PR TITLE
Read partial file that contains complete header

### DIFF
--- a/src/reader.rs
+++ b/src/reader.rs
@@ -32,9 +32,7 @@ impl<R: Read + Seek> Mp4Reader<R> {
             let header = BoxHeader::read(&mut reader)?;
             let BoxHeader { name, size: s } = header;
             if s > size {
-                return Err(Error::InvalidData(
-                    "file contains a box with a larger size than it",
-                ));
+                break;
             }
 
             // Break if size zero BoxHeader, which can result in dead-loop.


### PR DESCRIPTION
The modified version can read a partial MP4 file with a complete header.
The purpose of `Mp4Reader::read_header` is to read the header, not the entire file.