### PR TITLE
Allow sample_time to wrap

### DIFF
--- a/src/track.rs
+++ b/src/track.rs
@@ -520,12 +520,12 @@ impl Mp4Track {
                             )?;
                         }
                         let duration = trun.sample_durations[sample_idx];
-                        return Ok((base_start_time + start_offset, duration));
+                        return Ok((base_start_time.wrapping_add(start_offset), duration));
                     }
                 }
             }
             let start_offset = ((sample_id - 1) * default_sample_duration) as u64;
-            Ok((base_start_time + start_offset, default_sample_duration))
+            Ok((base_start_time.wrapping_add(start_offset), default_sample_duration))
         } else {
             let stts = &self.trak.mdia.minf.stbl.stts;
 

--- a/src/track.rs
+++ b/src/track.rs
@@ -261,7 +261,7 @@ impl Mp4Track {
 
     pub fn sequence_parameter_set(&self) -> Result<&[u8]> {
         if let Some(ref avc1) = self.trak.mdia.minf.stbl.stsd.avc1 {
-            match avc1.avcc.sequence_parameter_sets.get(0) {
+            match avc1.avcc.sequence_parameter_sets.first() {
                 Some(nal) => Ok(nal.bytes.as_ref()),
                 None => Err(Error::EntryInStblNotFound(
                     self.track_id(),
@@ -276,7 +276,7 @@ impl Mp4Track {
 
     pub fn picture_parameter_set(&self) -> Result<&[u8]> {
         if let Some(ref avc1) = self.trak.mdia.minf.stbl.stsd.avc1 {
-            match avc1.avcc.picture_parameter_sets.get(0) {
+            match avc1.avcc.picture_parameter_sets.first() {
                 Some(nal) => Ok(nal.bytes.as_ref()),
                 None => Err(Error::EntryInStblNotFound(
                     self.track_id(),

--- a/src/track.rs
+++ b/src/track.rs
@@ -525,7 +525,10 @@ impl Mp4Track {
                 }
             }
             let start_offset = ((sample_id - 1) * default_sample_duration) as u64;
-            Ok((base_start_time.wrapping_add(start_offset), default_sample_duration))
+            Ok((
+                base_start_time.wrapping_add(start_offset),
+                default_sample_duration,
+            ))
         } else {
             let stts = &self.trak.mdia.minf.stbl.stts;
 


### PR DESCRIPTION
This has no effective change in release builds, but removes a panic in debug builds.