### PR TITLE
Support multiple `trun` boxes in a single `traf` box

### DIFF
--- a/examples/mp4dump.rs
+++ b/examples/mp4dump.rs
@@ -123,7 +123,7 @@ fn get_boxes(file: File) -> Result<Vec<Box>> {
         for traf in moof.trafs.iter() {
             boxes.push(build_box(traf));
             boxes.push(build_box(&traf.tfhd));
-            if let Some(ref trun) = &traf.trun {
+            for trun in &traf.truns {
                 boxes.push(build_box(trun));
             }
         }

--- a/src/track.rs
+++ b/src/track.rs
@@ -261,7 +261,7 @@ impl Mp4Track {
 
     pub fn sequence_parameter_set(&self) -> Result<&[u8]> {
         if let Some(ref avc1) = self.trak.mdia.minf.stbl.stsd.avc1 {
-            match avc1.avcc.sequence_parameter_sets.get(0) {
+            match avc1.avcc.sequence_parameter_sets.first() {
                 Some(nal) => Ok(nal.bytes.as_ref()),
                 None => Err(Error::EntryInStblNotFound(
                     self.track_id(),
@@ -276,7 +276,7 @@ impl Mp4Track {
 
     pub fn picture_parameter_set(&self) -> Result<&[u8]> {
         if let Some(ref avc1) = self.trak.mdia.minf.stbl.stsd.avc1 {
-            match avc1.avcc.picture_parameter_sets.get(0) {
+            match avc1.avcc.picture_parameter_sets.first() {
                 Some(nal) => Ok(nal.bytes.as_ref()),
                 None => Err(Error::EntryInStblNotFound(
                     self.track_id(),


### PR DESCRIPTION
MPEG-4 part 12 section 8.8.8 states that a `traf` box may contain multiple `trun` boxes. This patch allows parsing such files correctly. Previously, the library would only parse the last `trun` box for each `traf` box, which caused the tracks to be unplayable.