### PR TITLE
Add support for the `avc3` box.

### DIFF
--- a/src/mp4box/mod.rs
+++ b/src/mp4box/mod.rs
@@ -26,6 +26,7 @@
 //!                 stbl
 //!                     stsd
 //!                         avc1
+//!                         avc3
 //!                         hev1
 //!                         mp4a
 //!                         tx3g
@@ -62,7 +63,7 @@ use std::io::{Read, Seek, SeekFrom, Write};
 
 use crate::*;
 
-pub(crate) mod avc1;
+pub(crate) mod avc;
 pub(crate) mod co64;
 pub(crate) mod ctts;
 pub(crate) mod data;
@@ -106,7 +107,7 @@ pub(crate) mod vmhd;
 pub(crate) mod vp09;
 pub(crate) mod vpcc;
 
-pub use avc1::Avc1Box;
+pub use avc::Avc1Box;
 pub use co64::Co64Box;
 pub use ctts::CttsBox;
 pub use data::DataBox;
@@ -223,6 +224,7 @@ boxtype! {
     UrlBox  => 0x75726C20,
     SmhdBox => 0x736d6864,
     Avc1Box => 0x61766331,
+    Avc3Box => 0x61766333,
     AvcCBox => 0x61766343,
     Hev1Box => 0x68657631,
     HvcCBox => 0x68766343,

--- a/src/mp4box/stsd.rs
+++ b/src/mp4box/stsd.rs
@@ -4,7 +4,12 @@ use std::io::{Read, Seek, Write};
 
 use crate::mp4box::vp09::Vp09Box;
 use crate::mp4box::*;
-use crate::mp4box::{avc1::Avc1Box, hev1::Hev1Box, mp4a::Mp4aBox, tx3g::Tx3gBox};
+use crate::mp4box::{
+    avc::{Avc1Box, Avc3Box},
+    hev1::Hev1Box,
+    mp4a::Mp4aBox,
+    tx3g::Tx3gBox,
+};
 
 #[derive(Debug, Clone, PartialEq, Eq, Default, Serialize)]
 pub struct StsdBox {
@@ -13,6 +18,9 @@ pub struct StsdBox {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub avc1: Option<Avc1Box>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub avc3: Option<Avc3Box>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub hev1: Option<Hev1Box>,
@@ -77,6 +85,7 @@ impl<R: Read + Seek> ReadBox<&mut R> for StsdBox {
         reader.read_u32::<BigEndian>()?; // XXX entry_count
 
         let mut avc1 = None;
+        let mut avc3 = None;
         let mut hev1 = None;
         let mut vp09 = None;
         let mut mp4a = None;
@@ -94,6 +103,9 @@ impl<R: Read + Seek> ReadBox<&mut R> for StsdBox {
         match name {
             BoxType::Avc1Box => {
                 avc1 = Some(Avc1Box::read_box(reader, s)?);
+            }
+            BoxType::Avc3Box => {
+                avc3 = Some(Avc3Box::read_box(reader, s)?);
             }
             BoxType::Hev1Box => {
                 hev1 = Some(Hev1Box::read_box(reader, s)?);
@@ -116,6 +128,7 @@ impl<R: Read + Seek> ReadBox<&mut R> for StsdBox {
             version,
             flags,
             avc1,
+            avc3,
             hev1,
             vp09,
             mp4a,


### PR DESCRIPTION
According to MPEG-4 part 15, sections 5.4.2.1.2 and 5.4.4 (or the whole 5.4 section in general), `avc1` and `avc3` have identical syntax and only differ in semantics. Since the change is trivial, there is no reason not to support both.