### PR TITLE
Add better handling of sample sizes for fragmented media

### DIFF
--- a/src/reader.rs
+++ b/src/reader.rs
@@ -98,9 +98,11 @@ impl<R: Read + Seek> Mp4Reader<R> {
         // Update tracks if any fragmented (moof) boxes are found.
         if !moofs.is_empty() {
             let mut default_sample_duration = 0;
+            let mut default_sample_size = 0;
             if let Some(ref moov) = moov {
                 if let Some(ref mvex) = &moov.mvex {
-                    default_sample_duration = mvex.trex.default_sample_duration
+                    default_sample_duration = mvex.trex.default_sample_duration;
+                    default_sample_size = mvex.trex.default_sample_size;
                 }
             }
 
@@ -109,6 +111,7 @@ impl<R: Read + Seek> Mp4Reader<R> {
                     let track_id = traf.tfhd.track_id;
                     if let Some(track) = tracks.get_mut(&track_id) {
                         track.default_sample_duration = default_sample_duration;
+                        track.default_sample_size = default_sample_size;
                         track.moof_offsets.push(moof_offset);
                         track.trafs.push(traf.clone())
                     } else {

--- a/src/track.rs
+++ b/src/track.rs
@@ -263,7 +263,7 @@ impl Mp4Track {
 
     pub fn sequence_parameter_set(&self) -> Result<&[u8]> {
         if let Some(ref avc1) = self.trak.mdia.minf.stbl.stsd.avc1 {
-            match avc1.avcc.sequence_parameter_sets.get(0) {
+            match avc1.avcc.sequence_parameter_sets.first() {
                 Some(nal) => Ok(nal.bytes.as_ref()),
                 None => Err(Error::EntryInStblNotFound(
                     self.track_id(),
@@ -278,7 +278,7 @@ impl Mp4Track {
 
     pub fn picture_parameter_set(&self) -> Result<&[u8]> {
         if let Some(ref avc1) = self.trak.mdia.minf.stbl.stsd.avc1 {
-            match avc1.avcc.picture_parameter_sets.get(0) {
+            match avc1.avcc.picture_parameter_sets.first() {
                 Some(nal) => Ok(nal.bytes.as_ref()),
                 None => Err(Error::EntryInStblNotFound(
                     self.track_id(),


### PR DESCRIPTION
This allows the sample size to be obtained from the mvex box and the tfhd box in addition to the trun sample entry