### PR TITLE
if s=0 would create dead-loop

### DIFF
--- a/src/mp4box/dinf.rs
+++ b/src/mp4box/dinf.rs
@@ -232,7 +232,7 @@ impl UrlBox {
         let mut size = HEADER_SIZE + HEADER_EXT_SIZE;
 
         if !self.location.is_empty() {
-            size += self.location.bytes().len() as u64 + 1;
+            size += self.location.len() as u64 + 1;
         }
 
         size

--- a/src/mp4box/ftyp.rs
+++ b/src/mp4box/ftyp.rs
@@ -53,6 +53,7 @@ impl<R: Read + Seek> ReadBox<&mut R> for FtypBox {
     fn read_box(reader: &mut R, size: u64) -> Result<Self> {
         let start = box_start(reader)?;
 
+        #[allow(clippy::manual_is_multiple_of)]
         if size < 16 || size % 4 != 0 {
             return Err(Error::InvalidData("ftyp size too small or not aligned"));
         }

--- a/src/mp4box/ilst.rs
+++ b/src/mp4box/ilst.rs
@@ -166,7 +166,7 @@ impl<R: Read + Seek> ReadBox<&mut R> for IlstItemBox {
 }
 
 impl<'a> Metadata<'a> for IlstBox {
-    fn title(&self) -> Option<Cow<str>> {
+    fn title(&'_ self) -> Option<Cow<'_, str>> {
         self.items.get(&MetadataKey::Title).map(item_to_str)
     }
 
@@ -178,7 +178,7 @@ impl<'a> Metadata<'a> for IlstBox {
         self.items.get(&MetadataKey::Poster).map(item_to_bytes)
     }
 
-    fn summary(&self) -> Option<Cow<str>> {
+    fn summary(&'_ self) -> Option<Cow<'_, str>> {
         self.items.get(&MetadataKey::Summary).map(item_to_str)
     }
 }
@@ -187,7 +187,7 @@ fn item_to_bytes(item: &IlstItemBox) -> &[u8] {
     &item.data.data
 }
 
-fn item_to_str(item: &IlstItemBox) -> Cow<str> {
+fn item_to_str(item: &'_ IlstItemBox) -> Cow<'_, str> {
     String::from_utf8_lossy(&item.data.data)
 }
 

--- a/src/mp4box/mod.rs
+++ b/src/mp4box/mod.rs
@@ -348,6 +348,10 @@ pub fn skip_bytes_to<S: Seek>(seeker: &mut S, pos: u64) -> Result<()> {
 
 pub fn skip_box<S: Seek>(seeker: &mut S, size: u64) -> Result<()> {
     let start = box_start(seeker)?;
+
+    // if we're jumping to the same place, it's probably a bug in the caller
+    assert!(size > 0);
+
     skip_bytes_to(seeker, start + size)?;
     Ok(())
 }

--- a/src/mp4box/mp4a.rs
+++ b/src/mp4box/mp4a.rs
@@ -285,7 +285,7 @@ fn size_of_length(size: u32) -> u32 {
 fn write_desc<W: Write>(writer: &mut W, tag: u8, size: u32) -> Result<u64> {
     writer.write_u8(tag)?;
 
-    if size as u64 > std::u32::MAX as u64 {
+    if size as u64 > u32::MAX as u64 {
         return Err(Error::InvalidData("invalid descriptor length range"));
     }
 

--- a/src/mp4box/stbl.rs
+++ b/src/mp4box/stbl.rs
@@ -98,6 +98,11 @@ impl<R: Read + Seek> ReadBox<&mut R> for StblBox {
                 ));
             }
 
+            // Break if size zero BoxHeader, which can result in dead-loop.
+            if s == 0 {
+                break;
+            }
+
             match name {
                 BoxType::StsdBox => {
                     stsd = Some(StsdBox::read_box(reader, s)?);

--- a/src/track.rs
+++ b/src/track.rs
@@ -261,7 +261,7 @@ impl Mp4Track {
 
     pub fn sequence_parameter_set(&self) -> Result<&[u8]> {
         if let Some(ref avc1) = self.trak.mdia.minf.stbl.stsd.avc1 {
-            match avc1.avcc.sequence_parameter_sets.get(0) {
+            match avc1.avcc.sequence_parameter_sets.first() {
                 Some(nal) => Ok(nal.bytes.as_ref()),
                 None => Err(Error::EntryInStblNotFound(
                     self.track_id(),
@@ -276,7 +276,7 @@ impl Mp4Track {
 
     pub fn picture_parameter_set(&self) -> Result<&[u8]> {
         if let Some(ref avc1) = self.trak.mdia.minf.stbl.stsd.avc1 {
-            match avc1.avcc.picture_parameter_sets.get(0) {
+            match avc1.avcc.picture_parameter_sets.first() {
                 Some(nal) => Ok(nal.bytes.as_ref()),
                 None => Err(Error::EntryInStblNotFound(
                     self.track_id(),
@@ -580,7 +580,7 @@ impl Mp4Track {
     fn is_sync_sample(&self, sample_id: u32) -> bool {
         if !self.trafs.is_empty() {
             let sample_sizes_count = self.sample_count() / self.trafs.len() as u32;
-            return sample_id == 1 || sample_id % sample_sizes_count == 0;
+            return sample_id == 1 || sample_id.is_multiple_of(sample_sizes_count);
         }
 
         if let Some(ref stss) = self.trak.mdia.minf.stbl.stss {

--- a/src/track.rs
+++ b/src/track.rs
@@ -580,7 +580,9 @@ impl Mp4Track {
     fn is_sync_sample(&self, sample_id: u32) -> bool {
         if !self.trafs.is_empty() {
             let sample_sizes_count = self.sample_count() / self.trafs.len() as u32;
-            return sample_id == 1 || sample_id.is_multiple_of(sample_sizes_count);
+
+            #[allow(clippy::manual_is_multiple_of)]
+            return sample_id == 1 || sample_id % sample_sizes_count == 0;
         }
 
         if let Some(ref stss) = self.trak.mdia.minf.stbl.stss {

--- a/src/types.rs
+++ b/src/types.rs
@@ -695,17 +695,17 @@ pub enum MetadataKey {
 
 pub trait Metadata<'a> {
     /// The video's title
-    fn title(&self) -> Option<Cow<str>>;
+    fn title(&'_ self) -> Option<Cow<'_, str>>;
     /// The video's release year
     fn year(&self) -> Option<u32>;
     /// The video's poster (cover art)
     fn poster(&self) -> Option<&[u8]>;
     /// The video's summary
-    fn summary(&self) -> Option<Cow<str>>;
+    fn summary(&self) -> Option<Cow<'_, str>>;
 }
 
 impl<'a, T: Metadata<'a>> Metadata<'a> for &'a T {
-    fn title(&self) -> Option<Cow<str>> {
+    fn title(&'_ self) -> Option<Cow<'_, str>> {
         (**self).title()
     }
 
@@ -717,13 +717,13 @@ impl<'a, T: Metadata<'a>> Metadata<'a> for &'a T {
         (**self).poster()
     }
 
-    fn summary(&self) -> Option<Cow<str>> {
+    fn summary(&self) -> Option<Cow<'_, str>> {
         (**self).summary()
     }
 }
 
 impl<'a, T: Metadata<'a>> Metadata<'a> for Option<T> {
-    fn title(&self) -> Option<Cow<str>> {
+    fn title(&'_ self) -> Option<Cow<'_, str>> {
         self.as_ref().and_then(|t| t.title())
     }
 
@@ -735,7 +735,7 @@ impl<'a, T: Metadata<'a>> Metadata<'a> for Option<T> {
         self.as_ref().and_then(|t| t.poster())
     }
 
-    fn summary(&self) -> Option<Cow<str>> {
+    fn summary(&'_ self) -> Option<Cow<'_, str>> {
         self.as_ref().and_then(|t| t.summary())
     }
 }

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -117,7 +117,7 @@ impl<W: Write + Seek> Mp4Writer<W> {
     fn update_mdat_size(&mut self) -> Result<()> {
         let mdat_end = self.writer.stream_position()?;
         let mdat_size = mdat_end - self.mdat_pos;
-        if mdat_size > std::u32::MAX as u64 {
+        if mdat_size > u32::MAX as u64 {
             self.writer.seek(SeekFrom::Start(self.mdat_pos))?;
             self.writer.write_u32::<BigEndian>(1)?;
             self.writer.seek(SeekFrom::Start(self.mdat_pos + 8))?;


### PR DESCRIPTION
the main change is adding the check

```rust
            // Break if size zero BoxHeader, which can result in dead-loop.
            if s == 0 {
                break;
            }
```

in `stbl.rs`, the dead-loop indeed happened for me in production, a user uploaded a currupted mp4 file and the process got stuck in a tight 100% cpu usage loop.


also added this assert in `skip_box` as a catch all for all other possible bugs, i assume here that correct code won't try skipping box to the same place
```rust
    // if we're jumping to the same place, it's probably a bug in the caller
    assert!(size > 0);
```

all other changes are just applying clippy suggestions to make the tests pass.