### PR TITLE
Return track_id from Mp4Writer::add_track

### DIFF
--- a/src/writer.rs
+++ b/src/writer.rs
@@ -85,11 +85,12 @@ impl<W: Write + Seek> Mp4Writer<W> {
         })
     }
 
-    pub fn add_track(&mut self, config: &TrackConfig) -> Result<()> {
+    /// Returns the track id of the newly created track.
+    pub fn add_track(&mut self, config: &TrackConfig) -> Result<u32> {
         let track_id = self.tracks.len() as u32 + 1;
         let track = Mp4TrackWriter::new(track_id, config)?;
         self.tracks.push(track);
-        Ok(())
+        Ok(track_id)
     }
 
     fn update_durations(&mut self, track_dur: u64) {


### PR DESCRIPTION
Marginally improves the developer experience of using Mp4Writer.